### PR TITLE
refactor: binlog persistent using parallel

### DIFF
--- a/mysql-test/suite/smartengine_consistent_snapshot/r/binlog_archive_fault_injection-wesql.result
+++ b/mysql-test/suite/smartengine_consistent_snapshot/r/binlog_archive_fault_injection-wesql.result
@@ -54,5 +54,38 @@ set global debug= '-d, force_rotate_forbidded';
 SELECT binlog_persistent_purge('binlog.000002');
 binlog_persistent_purge('binlog.000002')
 Purge binlog persistent files successfully
+# Wait for all binlog persistent
+# fault_injection_add_slice_queue 
+set global debug= '+d, fault_injection_add_slice_queue';
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+Pattern found.
+Pattern found.
+set global debug= '-d, fault_injection_add_slice_queue';
+# Wait for all binlog persistent
+# fault_injection_put_slice_to_objstore 
+set global debug= '+d, fault_injection_put_slice_to_objstore';
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+# Wait for all binlog add expected persistent queue.
+Pattern found.
+Pattern found.
+Pattern found.
+set global debug= '-d, fault_injection_put_slice_to_objstore';
+# Wait for all binlog persistent
+# fault_injection_binlog_archive_update_index_file 
+set global debug= '+d, fault_injection_binlog_archive_update_index_file';
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+Pattern found.
+Pattern found.
+set global debug= '-d, fault_injection_binlog_archive_update_index_file';
+# Wait for all binlog persistent
 DROP TABLE t1;
 DROP DATABASE db1;

--- a/mysql-test/suite/smartengine_consistent_snapshot/r/consistent_snapshot_fault_injection-wesql.result
+++ b/mysql-test/suite/smartengine_consistent_snapshot/r/consistent_snapshot_fault_injection-wesql.result
@@ -1,16 +1,16 @@
 # Wait for at least 1 snapshots to be generated 
 CREATE DATABASE db1;
-CREATE TABLE t1(c1 int) ENGINE=SMARTENGINE ;
-INSERT INTO t1 values(1);
-INSERT INTO t1 values(2);
-INSERT INTO t1 values(3);
-INSERT INTO t1 values(4);
+CREATE TABLE t1(c1 int, c2 char(200)) ENGINE=SMARTENGINE ;
+INSERT INTO t1 values(1, 'abcd');
+INSERT INTO t1 values(2, 'abcd');
+INSERT INTO t1 values(3, 'abcd');
+INSERT INTO t1 values(4, 'abcd');
 SELECT * FROM t1;
-c1
-1
-2
-3
-4
+c1	c2
+1	abcd
+2	abcd
+3	abcd
+4	abcd
 SELECT SNAPSHOT_ARCHIVE_PERSISTENT_FORCE();
 SNAPSHOT_ARCHIVE_PERSISTENT_FORCE()
 
@@ -93,6 +93,54 @@ Pattern found.
 Pattern found.
 Pattern found.
 Pattern found.
+# Wait for all binlog persistent
+# fault_injection_add_slice_queue 
+set global debug= '+d, fault_injection_add_slice_queue';
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+Pattern found.
+Pattern found.
+set global debug= '-d, fault_injection_add_slice_queue';
+# Wait for all binlog persistent
+# fault_injection_put_slice_to_objstore 
+set global debug= '+d, fault_injection_put_slice_to_objstore';
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+# Wait for all binlog add expected persistent queue.
+Pattern found.
+Pattern found.
+Pattern found.
+set global debug= '-d, fault_injection_put_slice_to_objstore';
+# Wait for all binlog persistent
+# fault_injection_binlog_archive_update_index_file 
+set global debug= '+d, fault_injection_binlog_archive_update_index_file';
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+Pattern found.
+Pattern found.
+set global debug= '-d, fault_injection_binlog_archive_update_index_file';
+# Wait for all binlog persistent
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+272
+include/stop_mysqld.inc [server 1]
+# Force rmdir datadir for recovery test
+# Create an empty data directory...
+# Recovery start from object store.
+# restart
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+272
 # Cleanup
 DROP TABLE t1;
 DROP DATABASE db1;

--- a/mysql-test/suite/smartengine_consistent_snapshot/r/consistent_snapshot_ro_clone-wesql.result
+++ b/mysql-test/suite/smartengine_consistent_snapshot/r/consistent_snapshot_ro_clone-wesql.result
@@ -1,0 +1,29 @@
+# Wait for at least 1 snapshots to be generated 
+CREATE TABLE t1(c1 int) ENGINE=SMARTENGINE ;
+INSERT INTO t1 values(1);
+INSERT INTO t1 values(2);
+INSERT INTO t1 values(3);
+INSERT INTO t1 values(4);
+INSERT INTO t1 values(5);
+SELECT SNAPSHOT_ARCHIVE_PERSISTENT_FORCE();
+SNAPSHOT_ARCHIVE_PERSISTENT_FORCE()
+
+# Wait for at least 2 snapshots to be generated 
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+SELECT count(*) FROM t1;
+count(*)
+20
+# Wait for all binlog persistent
+# Initialize ro server
+# Start ro server
+# Wait ro accept connection
+# Wait ro changed leader
+# Connection ro
+SELECT count(*) FROM t1;
+count(*)
+20
+# Shutdown ro
+# Cleanup ro
+# Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive.test
@@ -41,7 +41,7 @@ SHOW CREATE TABLE t1;
 # --source include/show_binary_logs.inc
 
 --echo # Wait for all binlog persistent
-let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_RAFT_INDEX = COMMIT_INDEX;
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
@@ -50,7 +50,7 @@ let $wait_timeout= 600;
 # SELECT SUBSTRING_INDEX(Log_slice_key, '/', -1) from INFORMATION_SCHEMA.BINLOG_PERSISTENT_SLICES order by Log_slice_key;
 # --enable_warnings
 
-let $wait_condition= SELECT last_persistent_binlog_pos = last_persistent_binlog_write_pos FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+let $wait_condition= SELECT LAST_PERSISTING_BINLOG_WRITE_POS = LAST_PERSISTED_BINLOG_POS FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
@@ -67,14 +67,14 @@ BEGIN;
 INSERT INTO t1 SELECT * FROM t1 limit 100;
 COMMIT;
 
-let $wait_condition= SELECT last_persistent_binlog_write_pos > last_persistent_binlog_pos  FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+let $wait_condition= SELECT LAST_PERSISTING_BINLOG_WRITE_POS > LAST_PERSISTING_BINLOG_POS  FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
 --echo #Rotate allowed
 set global debug= '-d, force_rotate_forbidded';
 
-let $wait_condition= SELECT last_persistent_binlog_pos = last_persistent_binlog_write_pos FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+let $wait_condition= SELECT LAST_PERSISTING_BINLOG_WRITE_POS = LAST_PERSISTED_BINLOG_POS FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_fault_injection.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_fault_injection.cnf
@@ -5,5 +5,5 @@
 [mysqld]
 binlog_archive_expire_auto_purge= false
 binlog_archive_slice_max_size= 4096
-binlog_archive_period=       5000
+binlog_archive_period=       1000
 snapshot_archive=            false

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_fault_injection.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_fault_injection.test
@@ -41,7 +41,7 @@ SHOW CREATE TABLE t1;
 # --source include/show_binary_logs.inc
 
 --echo # Wait for all binlog persistent
-let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_RAFT_INDEX = COMMIT_INDEX;
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
@@ -50,7 +50,7 @@ let $wait_timeout= 600;
 # SELECT SUBSTRING_INDEX(Log_slice_key, '/', -1) from INFORMATION_SCHEMA.BINLOG_PERSISTENT_SLICES order by Log_slice_key;
 # --enable_warnings
 
-let $wait_condition= SELECT last_persistent_binlog_pos = last_persistent_binlog_write_pos FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+let $wait_condition= SELECT LAST_PERSISTED_BINLOG_POS = LAST_PERSISTING_BINLOG_WRITE_POS FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
@@ -67,14 +67,14 @@ BEGIN;
 INSERT INTO t1 SELECT * FROM t1 limit 100;
 COMMIT;
 
-let $wait_condition= SELECT last_persistent_binlog_write_pos > last_persistent_binlog_pos  FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+let $wait_condition= SELECT LAST_PERSISTING_BINLOG_WRITE_POS > LAST_PERSISTING_BINLOG_POS  FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
 --echo #Rotate allowed
 set global debug= '-d, force_rotate_forbidded';
 
-let $wait_condition= SELECT last_persistent_binlog_pos = last_persistent_binlog_write_pos FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+let $wait_condition= SELECT LAST_PERSISTING_BINLOG_WRITE_POS = LAST_PERSISTED_BINLOG_POS FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
@@ -92,6 +92,107 @@ let $wait_timeout= 600;
 # --enable_warnings
 
 # --source include/show_binary_logs.inc
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+--let $error_log=$MYSQLTEST_VARDIR/log/mysqld.1.err
+
+# fault_injection_add_slice_queue
+--echo # fault_injection_add_slice_queue 
+set global debug= '+d, fault_injection_add_slice_queue';
+
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+
+--sleep 3
+
+--let $grep_file=$error_log
+--let $grep_pattern=fault_injection_add_slice_queue
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+--let $grep_file=$error_log
+--let $grep_pattern=binlog archive persistent abort
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+set global debug= '-d, fault_injection_add_slice_queue';
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+# fault_injection_put_slice_to_objstore
+--echo # fault_injection_put_slice_to_objstore 
+set global debug= '+d, fault_injection_put_slice_to_objstore';
+
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+
+--echo # Wait for all binlog add expected persistent queue.
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTING_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+--sleep 3
+
+--let $grep_file=$error_log
+--let $grep_pattern=fault_injection_put_slice_to_objstore
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+--let $grep_file=$error_log
+--let $grep_pattern=binlog slice persisted failed
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+--let $grep_file=$error_log
+--let $grep_pattern=check found update index failed
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+set global debug= '-d, fault_injection_put_slice_to_objstore';
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+# fault_injection_binlog_archive_update_index_file
+--echo # fault_injection_binlog_archive_update_index_file 
+set global debug= '+d, fault_injection_binlog_archive_update_index_file';
+
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+
+--sleep 3
+
+--let $grep_file=$error_log
+--let $grep_pattern=fault_injection_binlog_archive_update_index_file
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+--let $grep_file=$error_log
+--let $grep_pattern=check found update index failed
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+set global debug= '-d, fault_injection_binlog_archive_update_index_file';
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
 
 DROP TABLE t1;
 DROP DATABASE db1;

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_with_log_bin.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_with_log_bin.test
@@ -34,7 +34,7 @@ SELECT count(*) FROM t1;
 --source include/show_binary_logs.inc
 
 --echo # Wait for all binlog persistent
-let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_RAFT_INDEX = COMMIT_INDEX;
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
 let $wait_timeout= 600;
 # --source include/wait_condition_or_abort.inc
 

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/cluster_logger_binlog_archive.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/cluster_logger_binlog_archive.test
@@ -91,7 +91,7 @@ let $wait_timeout= 600;
 
 # --source include/show_binary_logs.inc
 
-let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_RAFT_INDEX = COMMIT_INDEX;
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/cluster_logger_rebuild.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/cluster_logger_rebuild.test
@@ -38,7 +38,7 @@ INSERT INTO t1 values(8);
 SELECT * FROM t1;
 
 --echo # Wait for all binlog persistent
-let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_RAFT_INDEX = COMMIT_INDEX;
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_fault_injection.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_fault_injection.cnf
@@ -5,4 +5,4 @@ log-bin=                                master-bin
 snapshot_archive_period=                1000
 snapshot_archive_expire_auto_purge=     false
 binlog_archive_expire_auto_purge=       false
-binlog_archive_period=                  3000
+binlog_archive_period=                  1000

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_fault_injection.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_fault_injection.cnf
@@ -4,5 +4,6 @@
 log-bin=                                master-bin
 snapshot_archive_period=                1000
 snapshot_archive_expire_auto_purge=     false
+binlog_archive_slice_max_size=          4096
 binlog_archive_expire_auto_purge=       false
 binlog_archive_period=                  1000

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_fault_injection.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_fault_injection.test
@@ -6,11 +6,11 @@ let $wait_condition= SELECT count(*) =1 FROM INFORMATION_SCHEMA.SNAPSHOT_PERSIST
 --source include/wait_condition_or_abort.inc
 
 CREATE DATABASE db1;
-CREATE TABLE t1(c1 int) ENGINE=SMARTENGINE ;
-INSERT INTO t1 values(1);
-INSERT INTO t1 values(2);
-INSERT INTO t1 values(3);
-INSERT INTO t1 values(4);
+CREATE TABLE t1(c1 int, c2 char(200)) ENGINE=SMARTENGINE ;
+INSERT INTO t1 values(1, 'abcd');
+INSERT INTO t1 values(2, 'abcd');
+INSERT INTO t1 values(3, 'abcd');
+INSERT INTO t1 values(4, 'abcd');
 SELECT * FROM t1;
 
 SELECT SNAPSHOT_ARCHIVE_PERSISTENT_FORCE();
@@ -134,6 +134,129 @@ let $wait_condition= SELECT count(*) = 8 FROM INFORMATION_SCHEMA.SNAPSHOT_PERSIS
 --let $grep_pattern=smartengine.index open failed in move_crash_safe_index_file_to_index_file
 --let $grep_output=boolean
 --source include/grep_pattern.inc
+
+##### binlog fault injection
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+# fault_injection_add_slice_queue
+--echo # fault_injection_add_slice_queue 
+set global debug= '+d, fault_injection_add_slice_queue';
+
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+
+--sleep 3
+
+--let $grep_file=$error_log
+--let $grep_pattern=fault_injection_add_slice_queue
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+--let $grep_file=$error_log
+--let $grep_pattern=binlog archive persistent abort
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+set global debug= '-d, fault_injection_add_slice_queue';
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+# fault_injection_put_slice_to_objstore
+--echo # fault_injection_put_slice_to_objstore 
+set global debug= '+d, fault_injection_put_slice_to_objstore';
+
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+
+--echo # Wait for all binlog add expected persistent queue.
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTING_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+--sleep 3
+
+--let $grep_file=$error_log
+--let $grep_pattern=fault_injection_put_slice_to_objstore
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+--let $grep_file=$error_log
+--let $grep_pattern=binlog slice persisted failed
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+--let $grep_file=$error_log
+--let $grep_pattern=check found update index failed
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+set global debug= '-d, fault_injection_put_slice_to_objstore';
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+# fault_injection_binlog_archive_update_index_file
+--echo # fault_injection_binlog_archive_update_index_file 
+set global debug= '+d, fault_injection_binlog_archive_update_index_file';
+
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+
+--sleep 3
+
+--let $grep_file=$error_log
+--let $grep_pattern=fault_injection_binlog_archive_update_index_file
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+--let $grep_file=$error_log
+--let $grep_pattern=check found update index failed
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+set global debug= '-d, fault_injection_binlog_archive_update_index_file';
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+INSERT INTO t1 values(1,'abcd');
+INSERT INTO t1 values(2,'abcd');
+INSERT INTO t1 values(3,'abcd');
+INSERT INTO t1 values(4,'abcd');
+SELECT COUNT(*) FROM t1;
+
+--let $MYSQLD_DATADIR=`select @@datadir`
+
+--source include/stop_mysqld.inc
+--source include/wait_until_disconnected.inc
+
+--echo # Force rmdir datadir for recovery test
+--force-rmdir $MYSQLD_DATADIR
+--echo # Create an empty data directory...
+--mkdir $MYSQLD_DATADIR
+
+# consistent snapshot recovery
+--echo # Recovery start from object store.
+--let $restart_parameters=restart
+--source include/start_mysqld.inc
+SELECT COUNT(*) FROM t1;
 
 --echo # Cleanup
 DROP TABLE t1;

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_recovery.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_recovery.cnf
@@ -4,5 +4,5 @@
 snapshot_archive_period=1
 snapshot_archive_expire_auto_purge=  false
 binlog_archive_expire_auto_purge=       false
-binlog_archive_period=                  3000
+binlog_archive_period=                  1000
 recovery_snapshot_from_objectstore=  true

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_recovery_with_log_bin.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_recovery_with_log_bin.cnf
@@ -6,5 +6,5 @@ log-bin=                    master-bin.index
 snapshot_archive_period=     1000
 snapshot_archive_expire_auto_purge=  false
 binlog_archive_expire_auto_purge=       false
-binlog_archive_period=                  3000
+binlog_archive_period=                  1000
 recovery_snapshot_from_objectstore=  true

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_recovery_with_log_bin.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_recovery_with_log_bin.test
@@ -18,7 +18,7 @@ INSERT INTO t1 values(1,'abcd');
 SELECT COUNT(*) FROM t1;
 
 --echo # Wait for all binlog persistent
-let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_RAFT_INDEX = COMMIT_INDEX;
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
@@ -71,7 +71,7 @@ INSERT INTO t1 SELECT * FROM t1;
 SELECT count(*) FROM t1;
 
 --echo # Wait for all binlog persistent
-let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_RAFT_INDEX = COMMIT_INDEX;
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 
@@ -113,7 +113,7 @@ INSERT INTO t1 SELECT * FROM t1;
 SELECT count(*) FROM t1;
 
 --echo # Wait for all binlog persistent
-let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_RAFT_INDEX = COMMIT_INDEX;
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
 let $wait_timeout= 600;
 --source include/wait_condition_or_abort.inc
 

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_recovery_with_tar_mode.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_recovery_with_tar_mode.cnf
@@ -4,5 +4,5 @@
 snapshot_archive_period=1
 snapshot_archive_expire_auto_purge=  false
 binlog_archive_expire_auto_purge=       false
-binlog_archive_period=                  3000
+binlog_archive_period=                  1000
 recovery_snapshot_from_objectstore= true

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_clone-master.opt
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_clone-master.opt
@@ -1,0 +1,1 @@
+--initialize=--objectstore-region=$MYSQL_TMP_DIR

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_clone.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_clone.cnf
@@ -2,7 +2,6 @@
 
 [mysqld]
 log-bin=                    master-bin
-snapshot_archive_period=     1
 snapshot_archive_expire_auto_purge=  false
 binlog_archive_expire_auto_purge=       false
 binlog_archive_period=                  1000

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_clone.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_clone.test
@@ -1,0 +1,98 @@
+#
+# Test for consistent snapshot from object store
+#
+
+--echo # Wait for at least 1 snapshots to be generated 
+let $wait_condition= SELECT count(*) >=1 FROM INFORMATION_SCHEMA.SNAPSHOT_PERSISTENT_SNAPSHOT_INDEX;
+--source include/wait_condition_or_abort.inc
+
+CREATE TABLE t1(c1 int) ENGINE=SMARTENGINE ;
+INSERT INTO t1 values(1);
+INSERT INTO t1 values(2);
+INSERT INTO t1 values(3);
+INSERT INTO t1 values(4);
+INSERT INTO t1 values(5);
+
+--let $source_region = `select @@objectstore_region`
+--let $source_bucket=`select @@objectstore_bucket`
+--let $source_repo = `select @@repo_objectstore_id`
+--let $source_server_id= `SELECT @@server_id`
+--let $source_port= `SELECT @@port`
+
+SELECT SNAPSHOT_ARCHIVE_PERSISTENT_FORCE();
+
+--echo # Wait for at least 2 snapshots to be generated 
+let $wait_condition= SELECT count(*) >=2 FROM INFORMATION_SCHEMA.SNAPSHOT_PERSISTENT_SNAPSHOT_INDEX;
+--source include/wait_condition_or_abort.inc
+
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+SELECT count(*) FROM t1;
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+let $ro_port = query_get_value("select $source_port+988 as c1", c1, 1);
+let $tmp_dir = $MYSQLTEST_VARDIR/tmp;
+let MYSQLD_DATADIR = $tmp_dir/snapshot_clone_ro_test;
+let MYSQLD_ERROR_LOG = $tmp_dir/ro_boost.err;
+let MYSQLD_ERROR_START_LOG = $tmp_dir/ro_start.err;
+let MYSQLD_EXTRA_INIT_ARGS = --initialize_from_objectstore=true --initialize_smartengine_objectstore_data=true --initialize_objectstore_region=$source_region --initialize_objectstore_bucket=$source_bucket --initialize_repo_objectstore_id=$source_repo;
+
+--echo # Initialize ro server
+let $MYSQLD_EXTRA_ARGS = --port=$ro_port --socket=$MYSQLD_DATADIR/test.sock --console --skip-ssl --log-bin=master-bin --objectstore-region=.local_region --log-error-verbosity=3 --datadir=$MYSQLD_DATADIR;
+--exec $MYSQLD --no-defaults $MYSQLD_ARGS $MYSQLD_EXTRA_ARGS $MYSQLD_EXTRA_INIT_ARGS --initialize-insecure > $MYSQLD_ERROR_LOG 2>&1
+--echo # Start ro server
+let $ro_cluster_info= '127.0.0.1:19981@1';
+--exec $MYSQLD --no-defaults $MYSQLD_ARGS $MYSQLD_EXTRA_ARGS --raft-replication-force-change-meta=ON --raft-replication-cluster-info=$ro_cluster_info --log-error=$MYSQLD_ERROR_START_LOG 2>&1 &
+
+--echo # Wait ro accept connection
+--disable_abort_on_error
+--disable_query_log
+--disable_result_log
+--let $mysql_errno= 9999
+--let $wait_counter= 300
+while ($mysql_errno)
+{
+  connect (ro,127.0.0.1,root,,test,$ro_port);
+  if ($mysql_errno == 1045){
+    --let mysql_errno=0
+  }
+  if ($mysql_errname == ER_SECURE_TRANSPORT_REQUIRED){
+    --let mysql_errno=0
+  }
+  if ($mysql_errno){
+    --sleep 0.1
+    --dec $wait_counter
+    if (!$wait_counter){
+      --die Server failed to connect new ro node
+    }
+  }
+}
+--enable_result_log
+--enable_query_log
+--enable_abort_on_error
+
+--echo # Wait ro changed leader
+let $wait_timeout= 60;
+let $wait_condition= select count(*)=1 from information_schema.wesql_cluster_local where role='leader';
+--source include/wait_condition.inc
+
+--echo # Connection ro
+--connection ro
+SELECT count(*) FROM t1;
+
+--echo # Shutdown ro
+--shutdown_server 0
+
+--echo # Cleanup ro
+--force-rmdir $MYSQLD_DATADIR
+--remove_file $MYSQLD_ERROR_LOG
+--remove_file $MYSQLD_ERROR_START_LOG
+
+--connection default
+
+--echo # Cleanup
+DROP TABLE t1;

--- a/patches/mysql-server-8.0.35.patch
+++ b/patches/mysql-server-8.0.35.patch
@@ -2664,10 +2664,10 @@ index ed1fb372a58..a6640aa74d3 100644
  EXECUTE stmt;
  DROP PREPARE stmt;
 diff --git a/share/messages_to_clients.txt b/share/messages_to_clients.txt
-index e010b378799..dda614b613b 100644
+index e010b378799..a6f94f8f194 100644
 --- a/share/messages_to_clients.txt
 +++ b/share/messages_to_clients.txt
-@@ -9978,6 +9978,54 @@ ER_WARN_DEPRECATED_WITH_NOTE
+@@ -9978,6 +9978,60 @@ ER_WARN_DEPRECATED_WITH_NOTE
  
  reserved-error-section 5000 5999
  
@@ -2719,14 +2719,20 @@ index e010b378799..dda614b613b 100644
 +
 +ER_FORCE_STORAGE_ENGINE_TO_SMARTENGINE
 +  eng "Force change storage engine from %s to smartengine in serverless mode"
++
++ER_WARN_PURGE_LOG_IN_BINLOG_ARCHIVE_NOT_RUNNING
++  eng "file %s was not purged because binlog arhive not running."
++
++ER_WARN_PURGE_LOG_NOT_PERSISTED
++  eng "file %s was not purged because it is not persisted log file."
  
  ################################################################################
  # DO NOT add messages for the error-log to this file;
 diff --git a/share/messages_to_error_log.txt b/share/messages_to_error_log.txt
-index cdef214ae5f..37fcb2bfb7d 100644
+index cdef214ae5f..7d4b4479f98 100644
 --- a/share/messages_to_error_log.txt
 +++ b/share/messages_to_error_log.txt
-@@ -12293,6 +12293,444 @@ ER_WARN_DEPRECATED_OR_BLOCKED_CIPHER
+@@ -12293,6 +12293,450 @@ ER_WARN_DEPRECATED_OR_BLOCKED_CIPHER
  # End of 8.0 error messages intended to be written to the server error log.
  #
  
@@ -3101,6 +3107,12 @@ index cdef214ae5f..37fcb2bfb7d 100644
 +ER_BINLOG_ARCHIVE_LOG
 +  eng "Binlog archive: %s."
 +
++ER_BINLOG_ARCHIVE_WORKER_LOG
++  eng "Binlog archive worker %d: %s."
++
++ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG
++  eng "Binlog archive update index worker: %s."
++
 +ER_BINLOG_ARCHIVE_STARTUP
 +  eng "Binlog archive startup: %s."
 +
@@ -3307,7 +3319,7 @@ index 5e20e06024e..5d5eebbcb4a 100644
    IO_CACHE m_io_cache;
  };
 diff --git a/sql/binlog.cc b/sql/binlog.cc
-index de76909ed3b..45d80dfa8e5 100644
+index de76909ed3b..f9f14586ae3 100644
 --- a/sql/binlog.cc
 +++ b/sql/binlog.cc
 @@ -40,6 +40,7 @@
@@ -3318,7 +3330,15 @@ index de76909ed3b..45d80dfa8e5 100644
  #include "sql/raii/thread_stage_guard.h"
  #include "sql_string.h"
  #include "template_utils.h"
-@@ -547,6 +548,16 @@ class MYSQL_BIN_LOG::Binlog_ofile : public Basic_ostream {
+@@ -85,6 +86,7 @@
+ #include "partition_info.h"
+ #include "prealloced_array.h"
+ #include "scope_guard.h"
++#include "sql/binlog_archive.h"
+ #include "sql/binlog/decompressing_event_object_istream.h"
+ #include "sql/binlog/global.h"
+ #include "sql/binlog/group_commit/bgc_ticket_manager.h"  // Bgc_ticket_manager
+@@ -547,6 +549,16 @@ class MYSQL_BIN_LOG::Binlog_ofile : public Basic_ostream {
      return false;
    }
  
@@ -3335,7 +3355,7 @@ index de76909ed3b..45d80dfa8e5 100644
    bool flush() { return m_pipeline_head->flush(); }
    bool sync() { return m_pipeline_head->sync(); }
    bool flush_and_sync() { return flush() || sync(); }
-@@ -1746,6 +1757,14 @@ bool MYSQL_BIN_LOG::write_transaction(THD *thd, binlog_cache_data *cache_data,
+@@ -1746,6 +1758,14 @@ bool MYSQL_BIN_LOG::write_transaction(THD *thd, binlog_cache_data *cache_data,
    DBUG_PRINT("info",
               ("transaction_length= %llu", gtid_event.transaction_length));
  
@@ -3350,7 +3370,7 @@ index de76909ed3b..45d80dfa8e5 100644
    bool ret = gtid_event.write(writer);
    if (ret) goto end;
  
-@@ -1777,8 +1796,12 @@ int MYSQL_BIN_LOG::gtid_end_transaction(THD *thd) {
+@@ -1777,8 +1797,12 @@ int MYSQL_BIN_LOG::gtid_end_transaction(THD *thd) {
  
    if (thd->owned_gtid.sidno > 0) {
      assert(thd->variables.gtid_next.type == ASSIGNED_GTID);
@@ -3365,7 +3385,7 @@ index de76909ed3b..45d80dfa8e5 100644
        /*
          If the binary log is disabled for this thread (either by
          log_bin=0 or sql_log_bin=0 or by log_replica_updates=0 for a
-@@ -3202,13 +3225,23 @@ bool purge_source_logs_to_file(THD *thd, const char *to_log) {
+@@ -3202,13 +3226,23 @@ bool purge_source_logs_to_file(THD *thd, const char *to_log) {
      case Shared_backup_lock_guard::Lock_result::oom:
        return purge_error_message(thd, LOG_INFO_MEM);
    }
@@ -3390,7 +3410,7 @@ index de76909ed3b..45d80dfa8e5 100644
    auto purge_error = mysql_bin_log.purge_logs(
        search_file_name, include_to_log, need_index_lock, need_update_threads,
        nullptr, auto_purge);
-@@ -3243,6 +3276,15 @@ bool purge_source_logs_before_date(THD *thd, time_t purge_time) {
+@@ -3243,6 +3277,15 @@ bool purge_source_logs_before_date(THD *thd, time_t purge_time) {
        return purge_error_message(thd, LOG_INFO_MEM);
    }
  
@@ -3406,7 +3426,7 @@ index de76909ed3b..45d80dfa8e5 100644
    // purge
    constexpr auto auto_purge{false};
    auto purge_error =
-@@ -3365,6 +3407,9 @@ bool show_binlog_events(THD *thd, MYSQL_BIN_LOG *binary_log) {
+@@ -3365,6 +3408,9 @@ bool show_binlog_events(THD *thd, MYSQL_BIN_LOG *binary_log) {
    DBUG_TRACE;
  
    assert(thd->lex->sql_command == SQLCOM_SHOW_BINLOG_EVENTS ||
@@ -3416,7 +3436,7 @@ index de76909ed3b..45d80dfa8e5 100644
           thd->lex->sql_command == SQLCOM_SHOW_RELAYLOG_EVENTS);
  
    if (binary_log->is_open()) {
-@@ -3515,6 +3560,10 @@ MYSQL_BIN_LOG::MYSQL_BIN_LOG(uint *sync_period, bool relay_log)
+@@ -3515,6 +3561,10 @@ MYSQL_BIN_LOG::MYSQL_BIN_LOG(uint *sync_period, bool relay_log)
        sync_period_ptr(sync_period),
        sync_counter(0),
        is_relay_log(relay_log),
@@ -3427,7 +3447,7 @@ index de76909ed3b..45d80dfa8e5 100644
        checksum_alg_reset(binary_log::BINLOG_CHECKSUM_ALG_UNDEF),
        relay_log_checksum_alg(binary_log::BINLOG_CHECKSUM_ALG_UNDEF),
        previous_gtid_set_relaylog(nullptr),
-@@ -4263,6 +4312,10 @@ static enum_read_gtids_from_binlog_status read_gtids_from_binlog(
+@@ -4263,6 +4313,10 @@ static enum_read_gtids_from_binlog_status read_gtids_from_binlog(
      switch (ev->get_type_code()) {
        case binary_log::FORMAT_DESCRIPTION_EVENT:
        case binary_log::ROTATE_EVENT:
@@ -3438,7 +3458,7 @@ index de76909ed3b..45d80dfa8e5 100644
          // do nothing; just accept this event and go to next
          break;
        case binary_log::PREVIOUS_GTIDS_LOG_EVENT: {
-@@ -4555,7 +4608,7 @@ bool MYSQL_BIN_LOG::init_gtid_sets(Gtid_set *all_gtids, Gtid_set *lost_gtids,
+@@ -4555,7 +4609,7 @@ bool MYSQL_BIN_LOG::init_gtid_sets(Gtid_set *all_gtids, Gtid_set *lost_gtids,
  
    Checkable_rwlock *sid_lock =
        is_relay_log ? all_gtids->get_sid_map()->get_sid_lock() : global_sid_lock;
@@ -3447,7 +3467,7 @@ index de76909ed3b..45d80dfa8e5 100644
      If this is a relay log, we must have the IO thread Master_info trx_parser
      in order to correctly feed it with relay log events.
    */
-@@ -4910,6 +4963,17 @@ bool MYSQL_BIN_LOG::open_binlog(
+@@ -4910,6 +4964,17 @@ bool MYSQL_BIN_LOG::open_binlog(
  
    Format_description_log_event s;
  
@@ -3465,7 +3485,7 @@ index de76909ed3b..45d80dfa8e5 100644
    if (m_binlog_file->is_empty()) {
      /*
        The binary log file was empty (probably newly created)
-@@ -5061,6 +5125,10 @@ bool MYSQL_BIN_LOG::open_binlog(
+@@ -5061,6 +5126,10 @@ bool MYSQL_BIN_LOG::open_binlog(
    }
    if (m_binlog_file->flush_and_sync()) goto err;
  
@@ -3476,7 +3496,67 @@ index de76909ed3b..45d80dfa8e5 100644
    if (write_file_name_to_index_file) {
      DBUG_EXECUTE_IF("crash_create_critical_before_update_index",
                      DBUG_SUICIDE(););
-@@ -6009,6 +6077,14 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
+@@ -5935,6 +6004,7 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
+   bool exit_loop = false;
+   LOG_INFO log_info;
+   THD *thd = current_thd;
++  LOG_INFO last_persisted_log_info;
+   DBUG_TRACE;
+   DBUG_PRINT("info", ("to_log= %s", to_log));
+ 
+@@ -5958,6 +6028,32 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
+     goto err;
+   }
+ 
++  if (opt_serverless && opt_binlog_archive) {
++    Binlog_archive *binlog_archive = Binlog_archive::get_instance();
++    mysql_mutex_t *binlog_archive_lock =
++        binlog_archive->get_binlog_archive_lock();
++    mysql_mutex_lock(binlog_archive_lock);
++    if (!binlog_archive->is_thread_running()) {
++      mysql_mutex_unlock(binlog_archive_lock);
++      if (!auto_purge)
++        push_warning_printf(
++            thd, Sql_condition::SL_WARNING,
++            ER_WARN_PURGE_LOG_IN_BINLOG_ARCHIVE_NOT_RUNNING,
++            ER_THD(thd, ER_WARN_PURGE_LOG_IN_BINLOG_ARCHIVE_NOT_RUNNING),
++            to_log);
++      goto err;
++    }
++    mysql_mutex_unlock(binlog_archive_lock);
++    binlog_archive->get_mysql_current_archive_binlog(&last_persisted_log_info,
++                                                     true);
++    if (last_persisted_log_info.log_file_name[0] == '\0') {
++      if (!auto_purge)
++        push_warning_printf(
++            thd, Sql_condition::SL_WARNING, ER_WARN_PURGE_LOG_NOT_PERSISTED,
++            ER_THD(thd, ER_WARN_PURGE_LOG_NOT_PERSISTED), to_log);
++      goto err;
++    }
++  }
+   /*
+     File name exists in index file; delete until we find this file
+     or a file that is used.
+@@ -5967,6 +6063,18 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
+ 
+   while ((compare_log_name(to_log, log_info.log_file_name) ||
+           (exit_loop = included))) {
++    if (opt_serverless && opt_binlog_archive) {
++      // If binlog_archive is enabled, check if log file is persisted by
++      // binlog_archive thread before purging it.
++      if (compare_log_name(last_persisted_log_info.log_file_name,
++                           log_info.log_file_name) > 0) {
++        if (!auto_purge)
++          push_warning_printf(
++              thd, Sql_condition::SL_WARNING, ER_WARN_PURGE_LOG_NOT_PERSISTED,
++              ER_THD(thd, ER_WARN_PURGE_LOG_NOT_PERSISTED), to_log);
++        break;
++      }
++    }
+     if (is_active(log_info.log_file_name)) {
+       if (!auto_purge)
+         push_warning_printf(
+@@ -6009,6 +6117,14 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
      goto err;
    }
  
@@ -3491,7 +3571,7 @@ index de76909ed3b..45d80dfa8e5 100644
    // Update gtid_state->lost_gtids
    if (!is_relay_log) {
      global_sid_lock->wrlock();
-@@ -6540,7 +6616,11 @@ int MYSQL_BIN_LOG::new_file_impl(
+@@ -6540,7 +6656,11 @@ int MYSQL_BIN_LOG::new_file_impl(
      goto end;
    }
  
@@ -3504,7 +3584,7 @@ index de76909ed3b..45d80dfa8e5 100644
      /* Save set of GTIDs of the last binlog into table on binlog rotation */
      if ((error = gtid_state->save_gtids_of_last_binlog_into_table())) {
        if (error == ER_RPL_GTID_TABLE_CANNOT_OPEN) {
-@@ -6607,6 +6687,11 @@ int MYSQL_BIN_LOG::new_file_impl(
+@@ -6607,6 +6727,11 @@ int MYSQL_BIN_LOG::new_file_impl(
      Rotate_log_event r(new_name + dirname_length(new_name), 0, LOG_EVENT_OFFSET,
                         is_relay_log ? Rotate_log_event::RELAY_LOG : 0);
  
@@ -3516,7 +3596,7 @@ index de76909ed3b..45d80dfa8e5 100644
      if (DBUG_EVALUATE_IF("fault_injection_new_file_rotate_event", (error = 1),
                           false) ||
          (error = write_event_to_binlog(&r))) {
-@@ -6864,6 +6949,24 @@ bool MYSQL_BIN_LOG::truncate_update_log_file(const char *log_name,
+@@ -6864,6 +6989,24 @@ bool MYSQL_BIN_LOG::truncate_update_log_file(const char *log_name,
    return true;
  }
  
@@ -3541,7 +3621,7 @@ index de76909ed3b..45d80dfa8e5 100644
  bool MYSQL_BIN_LOG::write_event(Log_event *ev, Master_info *mi) {
    DBUG_TRACE;
  
-@@ -7198,6 +7301,14 @@ void MYSQL_BIN_LOG::auto_purge_at_server_startup() {
+@@ -7198,6 +7341,14 @@ void MYSQL_BIN_LOG::auto_purge_at_server_startup() {
  
    auto purge_time = calculate_auto_purge_lower_time_bound();
    constexpr auto auto_purge{true};
@@ -3556,7 +3636,7 @@ index de76909ed3b..45d80dfa8e5 100644
    purge_logs_before_date(purge_time, auto_purge);
  }
  
-@@ -7249,6 +7360,14 @@ void MYSQL_BIN_LOG::auto_purge() {
+@@ -7249,6 +7400,14 @@ void MYSQL_BIN_LOG::auto_purge() {
      is persisted inside storage engines.
    */
    ha_flush_logs();
@@ -3571,7 +3651,7 @@ index de76909ed3b..45d80dfa8e5 100644
    purge_logs_before_date(purge_time, auto_purge);
  }
  
-@@ -7534,13 +7653,13 @@ bool MYSQL_BIN_LOG::write_incident(Incident_log_event *ev, THD *thd,
+@@ -7534,13 +7693,13 @@ bool MYSQL_BIN_LOG::write_incident(Incident_log_event *ev, THD *thd,
        cache_mngr->stmt_cache.reset();
        return error;
      }
@@ -3588,7 +3668,7 @@ index de76909ed3b..45d80dfa8e5 100644
    if (do_flush_and_sync) {
      if (!error && !(error = flush_and_sync())) {
        bool check_purge = false;
-@@ -7935,6 +8054,11 @@ int MYSQL_BIN_LOG::open_binlog(const char *opt_name) {
+@@ -7935,6 +8094,11 @@ int MYSQL_BIN_LOG::open_binlog(const char *opt_name) {
      return 1;
    }
  
@@ -3600,7 +3680,7 @@ index de76909ed3b..45d80dfa8e5 100644
    if (using_heuristic_recover()) {
      /* generate a new binlog to mask a corrupted one */
      mysql_mutex_lock(&LOCK_log);
-@@ -8184,6 +8308,15 @@ TC_LOG::enum_result MYSQL_BIN_LOG::commit(THD *thd, bool all) {
+@@ -8184,6 +8348,15 @@ TC_LOG::enum_result MYSQL_BIN_LOG::commit(THD *thd, bool all) {
    if (cache_mngr == nullptr) {
      if (!skip_commit && trx_coordinator::commit_in_engines(thd, all))
        return RESULT_ABORTED;
@@ -3616,7 +3696,7 @@ index de76909ed3b..45d80dfa8e5 100644
      return RESULT_SUCCESS;
    }
  
-@@ -8399,6 +8532,15 @@ TC_LOG::enum_result MYSQL_BIN_LOG::commit(THD *thd, bool all) {
+@@ -8399,6 +8572,15 @@ TC_LOG::enum_result MYSQL_BIN_LOG::commit(THD *thd, bool all) {
      if (trx_coordinator::commit_in_engines(thd, all))
        return RESULT_INCONSISTENT;
    }
@@ -3632,7 +3712,7 @@ index de76909ed3b..45d80dfa8e5 100644
  
    return RESULT_SUCCESS;
  }
-@@ -8600,6 +8742,13 @@ void MYSQL_BIN_LOG::process_commit_stage_queue(THD *thd, THD *first) {
+@@ -8600,6 +8782,13 @@ void MYSQL_BIN_LOG::process_commit_stage_queue(THD *thd, THD *first) {
        m_dependency_tracker.update_max_committed(head);
        mysql_mutex_unlock(&LOCK_replica_trans_dep_tracker);
      }
@@ -3646,7 +3726,7 @@ index de76909ed3b..45d80dfa8e5 100644
      /*
        Flush/Sync error should be ignored and continue
        to commit phase. And thd->commit_error cannot be
-@@ -8608,6 +8757,7 @@ void MYSQL_BIN_LOG::process_commit_stage_queue(THD *thd, THD *first) {
+@@ -8608,6 +8797,7 @@ void MYSQL_BIN_LOG::process_commit_stage_queue(THD *thd, THD *first) {
      assert(head->commit_error != THD::CE_COMMIT_ERROR);
      Thd_backup_and_restore switch_thd(thd, head);
      bool all = head->get_transaction()->m_flags.real_commit;
@@ -3654,7 +3734,7 @@ index de76909ed3b..45d80dfa8e5 100644
      assert(!head->get_transaction()->m_flags.commit_low ||
             head->get_transaction()->m_flags.ready_preempt);
      ::finish_transaction_in_engines(head, all, false);
-@@ -8624,6 +8774,15 @@ void MYSQL_BIN_LOG::process_commit_stage_queue(THD *thd, THD *first) {
+@@ -8624,6 +8814,15 @@ void MYSQL_BIN_LOG::process_commit_stage_queue(THD *thd, THD *first) {
  
    for (THD *head = first; head; head = head->next_to_commit) {
      Thd_backup_and_restore switch_thd(thd, head);
@@ -3670,7 +3750,7 @@ index de76909ed3b..45d80dfa8e5 100644
      auto all = head->get_transaction()->m_flags.real_commit;
      // Mark transaction as prepared in TC, if applicable
      trx_coordinator::set_prepared_in_tc_in_engines(head, all);
-@@ -8780,7 +8939,17 @@ int MYSQL_BIN_LOG::finish_commit(THD *thd) {
+@@ -8780,7 +8979,17 @@ int MYSQL_BIN_LOG::finish_commit(THD *thd) {
    auto all = thd->get_transaction()->m_flags.real_commit;
    auto committed_low = thd->get_transaction()->m_flags.commit_low;
  
@@ -3688,7 +3768,7 @@ index de76909ed3b..45d80dfa8e5 100644
    ::finish_transaction_in_engines(thd, all, false);
  
    // If the ordered commit didn't updated the GTIDs for this thd yet
-@@ -8807,6 +8976,11 @@ int MYSQL_BIN_LOG::finish_commit(THD *thd) {
+@@ -8807,6 +9016,11 @@ int MYSQL_BIN_LOG::finish_commit(THD *thd) {
      thd->get_transaction()->m_flags.run_hooks = false;
    }
  
@@ -3700,7 +3780,7 @@ index de76909ed3b..45d80dfa8e5 100644
    DBUG_EXECUTE_IF("leaving_finish_commit", {
      const char act[] = "now SIGNAL signal_leaving_finish_commit";
      assert(!debug_sync_set_action(current_thd, STRING_WITH_LEN(act)));
-@@ -8917,6 +9091,17 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit) {
+@@ -8917,6 +9131,17 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit) {
    my_off_t total_bytes = 0;
    bool do_rotate = false;
  
@@ -3718,7 +3798,7 @@ index de76909ed3b..45d80dfa8e5 100644
    CONDITIONAL_SYNC_POINT_FOR_TIMESTAMP("before_assign_session_to_bgc_ticket");
    thd->rpl_thd_ctx.binlog_group_commit_ctx().assign_ticket();
  
-@@ -8990,12 +9175,28 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit) {
+@@ -8990,12 +9215,28 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit) {
    flush_error =
        process_flush_stage_queue(&total_bytes, &do_rotate, &wait_queue);
  
@@ -3747,7 +3827,7 @@ index de76909ed3b..45d80dfa8e5 100644
    /*
      If the flush finished successfully, we can call the after_flush
      hook. Being invoked here, we have the guarantee that the hook is
-@@ -9062,6 +9263,15 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit) {
+@@ -9062,6 +9303,15 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit) {
      sync_error = result.first;
    }
  
@@ -3763,7 +3843,7 @@ index de76909ed3b..45d80dfa8e5 100644
    if (update_binlog_end_pos_after_sync && flush_error == 0 && sync_error == 0) {
      THD *tmp_thd = final_queue;
      const char *binlog_file = nullptr;
-@@ -9158,6 +9368,13 @@ commit_stage:
+@@ -9158,6 +9408,13 @@ commit_stage:
        mysql_mutex_unlock(leave_mutex_before_commit_stage);
      if (flush_error == 0 && sync_error == 0)
        sync_error = call_after_sync_hook(final_queue);
@@ -3777,7 +3857,7 @@ index de76909ed3b..45d80dfa8e5 100644
    }
  
    /*
-@@ -9198,6 +9415,15 @@ commit_stage:
+@@ -9198,6 +9455,15 @@ commit_stage:
      */
  
      DEBUG_SYNC(thd, "ready_to_do_rotation");
@@ -3793,7 +3873,7 @@ index de76909ed3b..45d80dfa8e5 100644
      bool check_purge = false;
      mysql_mutex_lock(&LOCK_log);
      /*
-@@ -9211,6 +9437,10 @@ commit_stage:
+@@ -9211,6 +9477,10 @@ commit_stage:
        thd->commit_error = THD::CE_COMMIT_ERROR;
      else if (check_purge)
        auto_purge();
@@ -3804,7 +3884,7 @@ index de76909ed3b..45d80dfa8e5 100644
    }
    /*
      flush or sync errors are handled above (using binlog_error_action).
-@@ -9369,6 +9599,16 @@ inline void MYSQL_BIN_LOG::update_binlog_end_pos(const char *file,
+@@ -9369,6 +9639,16 @@ inline void MYSQL_BIN_LOG::update_binlog_end_pos(const char *file,
    unlock_binlog_end_pos();
  }
  
@@ -3821,7 +3901,7 @@ index de76909ed3b..45d80dfa8e5 100644
  bool THD::is_binlog_cache_empty(bool is_transactional) const {
    DBUG_TRACE;
  
-@@ -11699,3 +11939,7 @@ mysql_declare_plugin(binlog){
+@@ -11699,3 +11979,7 @@ mysql_declare_plugin(binlog){
      nullptr, /* config options                  */
      0,
  } mysql_declare_plugin_end;
@@ -4572,7 +4652,7 @@ index c288026b810..22d6c7b9d24 100644
  
  #endif /* _log_event_h */
 diff --git a/sql/mysqld.cc b/sql/mysqld.cc
-index 3f94e768956..56eb1254522 100644
+index 3f94e768956..e9cf788165b 100644
 --- a/sql/mysqld.cc
 +++ b/sql/mysqld.cc
 @@ -774,15 +774,18 @@ MySQL clients support the protocol:
@@ -4619,7 +4699,7 @@ index 3f94e768956..56eb1254522 100644
  bool opt_initialize = false;
  bool opt_skip_replica_start = false;  ///< If set, slave is not autostarted
  bool opt_enable_named_pipe = false;
-@@ -1500,6 +1510,64 @@ char server_version[SERVER_VERSION_LENGTH];
+@@ -1500,6 +1510,65 @@ char server_version[SERVER_VERSION_LENGTH];
  const char *mysqld_unix_port;
  char *opt_mysql_tmpdir;
  
@@ -4641,6 +4721,7 @@ index 3f94e768956..56eb1254522 100644
 +bool opt_binlog_archive_expire_auto_purge = true;
 +ulong opt_binlog_archive_expire_seconds = 0;
 +ulonglong opt_binlog_archive_period = 0;
++ulong opt_binlog_archive_parallel_workers = 0;
 +char *opt_consistent_snapshot_archive_dir = nullptr;
 +bool opt_consistent_snapshot_persistent_on_objstore = false;
 +bool opt_initialize_use_objstore = false;
@@ -4684,7 +4765,7 @@ index 3f94e768956..56eb1254522 100644
  char *opt_authentication_policy;
  std::vector<std::string> authentication_policy_list;
  /*
-@@ -2362,6 +2430,11 @@ static void close_connections(void) {
+@@ -2362,6 +2431,11 @@ static void close_connections(void) {
    Call_close_conn call_close_conn(true);
    thd_manager->do_for_all_thd(&call_close_conn);
  
@@ -4696,7 +4777,7 @@ index 3f94e768956..56eb1254522 100644
    (void)RUN_HOOK(server_state, after_server_shutdown, (nullptr));
  
    /*
-@@ -2493,6 +2566,8 @@ void clean_up_mysqld_mutexes() { clean_up_mutexes(); }
+@@ -2493,6 +2567,8 @@ void clean_up_mysqld_mutexes() { clean_up_mutexes(); }
  static void mysqld_exit(int exit_code) {
    assert((exit_code >= MYSQLD_SUCCESS_EXIT && exit_code <= MYSQLD_ABORT_EXIT) ||
           exit_code == MYSQLD_RESTART_EXIT);
@@ -4705,7 +4786,7 @@ index 3f94e768956..56eb1254522 100644
    mysql_audit_finalize();
    Srv_session::module_deinit();
    delete_optimizer_cost_module();
-@@ -4272,6 +4347,10 @@ SHOW_VAR com_status_vars[] = {
+@@ -4272,6 +4348,10 @@ SHOW_VAR com_status_vars[] = {
       (char *)offsetof(System_status_var,
                        com_stat[(uint)SQLCOM_SHOW_BINLOG_EVENTS]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4716,7 +4797,7 @@ index 3f94e768956..56eb1254522 100644
      {"show_binlogs",
       (char *)offsetof(System_status_var, com_stat[(uint)SQLCOM_SHOW_BINLOGS]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
-@@ -4443,6 +4522,14 @@ SHOW_VAR com_status_vars[] = {
+@@ -4443,6 +4523,14 @@ SHOW_VAR com_status_vars[] = {
       (char *)offsetof(System_status_var,
                        com_stat[(uint)SQLCOM_STOP_GROUP_REPLICATION]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4731,7 +4812,7 @@ index 3f94e768956..56eb1254522 100644
      {"stmt_execute", (char *)offsetof(System_status_var, com_stmt_execute),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
      {"stmt_close", (char *)offsetof(System_status_var, com_stmt_close),
-@@ -4498,6 +4585,16 @@ SHOW_VAR com_status_vars[] = {
+@@ -4498,6 +4586,16 @@ SHOW_VAR com_status_vars[] = {
      {"xa_start",
       (char *)offsetof(System_status_var, com_stat[(uint)SQLCOM_XA_START]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4748,7 +4829,7 @@ index 3f94e768956..56eb1254522 100644
      {NullS, NullS, SHOW_LONG, SHOW_SCOPE_ALL}};
  
  LEX_CSTRING sql_statement_names[(uint)SQLCOM_END + 1];
-@@ -4817,6 +4914,9 @@ int init_common_variables() {
+@@ -4817,6 +4915,9 @@ int init_common_variables() {
    */
    mysql_bin_log.init_pthread_objects();
  
@@ -4758,7 +4839,7 @@ index 3f94e768956..56eb1254522 100644
    /* TODO: remove this when my_time_t is 64 bit compatible */
    if (!is_time_t_valid_for_timestamp(server_start_time)) {
      LogErr(ERROR_LEVEL, ER_UNSUPPORTED_DATE);
-@@ -4859,6 +4959,12 @@ int init_common_variables() {
+@@ -4859,6 +4960,12 @@ int init_common_variables() {
    default_storage_engine = "InnoDB";
    default_tmp_storage_engine = default_storage_engine;
  
@@ -4771,7 +4852,7 @@ index 3f94e768956..56eb1254522 100644
    /*
      Add server status variables to the dynamic list of
      status variables that is shown by SHOW STATUS.
-@@ -6286,6 +6392,14 @@ static int init_server_components() {
+@@ -6286,6 +6393,14 @@ static int init_server_components() {
        opt_bin_logname = my_strdup(key_memory_opt_bin_logname, buf, MYF(0));
      }
  
@@ -4786,7 +4867,7 @@ index 3f94e768956..56eb1254522 100644
      /*
        Skip opening the index file if we start with --help. This is necessary
        to avoid creating the file in an otherwise empty datadir, which will
-@@ -6503,6 +6617,35 @@ static int init_server_components() {
+@@ -6503,6 +6618,35 @@ static int init_server_components() {
        LogErr(ERROR_LEVEL, ER_CANT_INITIALIZE_BUILTIN_PLUGINS);
      unireg_abort(1);
    }
@@ -4822,7 +4903,7 @@ index 3f94e768956..56eb1254522 100644
  
    /*
      Needs to be done before dd::init() which runs DDL commands (for real)
-@@ -6785,6 +6928,27 @@ static int init_server_components() {
+@@ -6785,6 +6929,27 @@ static int init_server_components() {
      unireg_abort(1);
    }
  
@@ -4850,7 +4931,7 @@ index 3f94e768956..56eb1254522 100644
    if (opt_initialize) log_output_options = LOG_FILE;
  
    /*
-@@ -6818,6 +6982,20 @@ static int init_server_components() {
+@@ -6818,6 +6983,20 @@ static int init_server_components() {
    /*
      Set the default storage engines
    */
@@ -4871,7 +4952,7 @@ index 3f94e768956..56eb1254522 100644
    if (initialize_storage_engine(default_storage_engine, "",
                                  &global_system_variables.table_plugin))
      unireg_abort(MYSQLD_ABORT_EXIT);
-@@ -6890,7 +7068,20 @@ static int init_server_components() {
+@@ -6890,7 +7069,20 @@ static int init_server_components() {
      unireg_abort(MYSQLD_ABORT_EXIT);
    }
  
@@ -4893,7 +4974,7 @@ index 3f94e768956..56eb1254522 100644
      /*
        Configures what object is used by the current log to store processed
        gtid(s). This is necessary in the MYSQL_BIN_LOG::MYSQL_BIN_LOG to
-@@ -7531,6 +7722,11 @@ int mysqld_main(int argc, char **argv)
+@@ -7531,6 +7723,11 @@ int mysqld_main(int argc, char **argv)
    */
    init_server_psi_keys();
  
@@ -4905,7 +4986,7 @@ index 3f94e768956..56eb1254522 100644
    /*
      Now that some instrumentation is in place,
      recreate objects which were initialised early,
-@@ -7830,6 +8026,63 @@ int mysqld_main(int argc, char **argv)
+@@ -7830,6 +8027,63 @@ int mysqld_main(int argc, char **argv)
      unireg_abort(MYSQLD_ABORT_EXIT); /* purecov: inspected */
    }
  
@@ -4969,7 +5050,7 @@ index 3f94e768956..56eb1254522 100644
    /*
     The subsequent calls may take a long time : e.g. innodb log read.
     Thus set the long running service control manager timeout
-@@ -7879,6 +8132,16 @@ int mysqld_main(int argc, char **argv)
+@@ -7879,6 +8133,16 @@ int mysqld_main(int argc, char **argv)
      if (gtid_state->read_gtid_executed_from_table() == -1) unireg_abort(1);
    }
  
@@ -4986,7 +5067,7 @@ index 3f94e768956..56eb1254522 100644
    if (opt_bin_log) {
      /*
        Initialize GLOBAL.GTID_EXECUTED and GLOBAL.GTID_PURGED from
-@@ -7998,6 +8261,14 @@ int mysqld_main(int argc, char **argv)
+@@ -7998,6 +8262,14 @@ int mysqld_main(int argc, char **argv)
      (void)RUN_HOOK(server_state, after_engine_recovery, (nullptr));
    }
  
@@ -5001,7 +5082,7 @@ index 3f94e768956..56eb1254522 100644
    if (init_ssl_communication()) unireg_abort(MYSQLD_ABORT_EXIT);
    if (network_init()) unireg_abort(MYSQLD_ABORT_EXIT);
  
-@@ -8133,8 +8404,22 @@ int mysqld_main(int argc, char **argv)
+@@ -8133,8 +8405,22 @@ int mysqld_main(int argc, char **argv)
  
    initialize_information_schema_acl();
  
@@ -5024,7 +5105,7 @@ index 3f94e768956..56eb1254522 100644
    if (Events::init(opt_noacl || opt_initialize))
      unireg_abort(MYSQLD_ABORT_EXIT);
  
-@@ -9267,6 +9552,12 @@ struct my_option my_long_options[] = {
+@@ -9267,6 +9553,12 @@ struct my_option my_long_options[] = {
       &opt_upgrade_mode, &opt_upgrade_mode, &upgrade_mode_typelib, GET_ENUM,
       REQUIRED_ARG, UPGRADE_AUTO, 0, 0, nullptr, 0, nullptr},
  
@@ -5037,7 +5118,7 @@ index 3f94e768956..56eb1254522 100644
      {nullptr, 0, nullptr, nullptr, nullptr, nullptr, GET_NO_ARG, NO_ARG, 0, 0,
       0, nullptr, 0, nullptr}};
  
-@@ -11131,6 +11422,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
+@@ -11131,6 +11423,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
  #ifndef _WIN32
    if (mysqld_chroot) set_root(mysqld_chroot);
  #endif
@@ -5045,7 +5126,7 @@ index 3f94e768956..56eb1254522 100644
    if (fix_paths()) return 1;
  
    /*
-@@ -11184,6 +11476,11 @@ static void set_server_version(void) {
+@@ -11184,6 +11477,11 @@ static void set_server_version(void) {
  #ifndef NDEBUG
    if (!strstr(MYSQL_SERVER_SUFFIX_STR, "-debug"))
      end = my_stpcpy(end, "-debug");
@@ -5057,7 +5138,7 @@ index 3f94e768956..56eb1254522 100644
  #endif
  #ifdef HAVE_VALGRIND
    if (SERVER_VERSION_LENGTH - (end - server_version) >
-@@ -11795,6 +12092,13 @@ PSI_mutex_key key_monitor_info_run_lock;
+@@ -11795,6 +12093,13 @@ PSI_mutex_key key_monitor_info_run_lock;
  PSI_mutex_key key_LOCK_delegate_connection_mutex;
  PSI_mutex_key key_LOCK_group_replication_connection_mutex;
  
@@ -5071,7 +5152,7 @@ index 3f94e768956..56eb1254522 100644
  /* clang-format off */
  static PSI_mutex_info all_server_mutexes[]=
  {
-@@ -11861,6 +12165,12 @@ static PSI_mutex_info all_server_mutexes[]=
+@@ -11861,6 +12166,12 @@ static PSI_mutex_info all_server_mutexes[]=
    { &key_mutex_slave_parallel_pend_jobs, "Relay_log_info::pending_jobs_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_mutex_slave_parallel_worker_count, "Relay_log_info::exit_count_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_mutex_slave_parallel_worker, "Worker_info::jobs_lock", 0, 0, PSI_DOCUMENT_ME},
@@ -5084,7 +5165,7 @@ index 3f94e768956..56eb1254522 100644
    { &key_TABLE_SHARE_LOCK_ha_data, "TABLE_SHARE::LOCK_ha_data", 0, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_error_messages, "LOCK_error_messages", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_log_throttle_qni, "LOCK_log_throttle_qni", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
-@@ -11887,7 +12197,7 @@ static PSI_mutex_info all_server_mutexes[]=
+@@ -11887,7 +12198,7 @@ static PSI_mutex_info all_server_mutexes[]=
    { &key_monitor_info_run_lock, "Source_IO_monitor::run_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_delegate_connection_mutex, "LOCK_delegate_connection_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_group_replication_connection_mutex, "LOCK_group_replication_connection_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
@@ -5093,7 +5174,7 @@ index 3f94e768956..56eb1254522 100644
    { &key_LOCK_global_conn_mem_limit, "LOCK_global_conn_mem_limit", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME}
  };
  /* clang-format on */
-@@ -11906,6 +12216,14 @@ PSI_rwlock_key key_rwlock_Binlog_transmit_delegate_lock;
+@@ -11906,6 +12217,14 @@ PSI_rwlock_key key_rwlock_Binlog_transmit_delegate_lock;
  PSI_rwlock_key key_rwlock_Binlog_relay_IO_delegate_lock;
  PSI_rwlock_key key_rwlock_resource_group_mgr_map_lock;
  
@@ -5108,7 +5189,7 @@ index 3f94e768956..56eb1254522 100644
  /* clang-format off */
  static PSI_rwlock_info all_server_rwlocks[]=
  {
-@@ -11922,6 +12240,13 @@ static PSI_rwlock_info all_server_rwlocks[]=
+@@ -11922,6 +12241,13 @@ static PSI_rwlock_info all_server_rwlocks[]=
    { &key_rwlock_Trans_delegate_lock, "Trans_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_Server_state_delegate_lock, "Server_state_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_Binlog_storage_delegate_lock, "Binlog_storage_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
@@ -5122,7 +5203,7 @@ index 3f94e768956..56eb1254522 100644
    { &key_rwlock_receiver_sid_lock, "gtid_retrieved", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_rpl_filter_lock, "rpl_filter_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_channel_to_filter_lock, "channel_to_filter_lock", 0, 0, PSI_DOCUMENT_ME},
-@@ -11960,6 +12285,12 @@ PSI_cond_key key_cond_slave_worker_hash;
+@@ -11960,6 +12286,12 @@ PSI_cond_key key_cond_slave_worker_hash;
  PSI_cond_key key_monitor_info_run_cond;
  PSI_cond_key key_COND_delegate_connection_cond_var;
  PSI_cond_key key_COND_group_replication_connection_cond_var;
@@ -5135,7 +5216,7 @@ index 3f94e768956..56eb1254522 100644
  
  /* clang-format off */
  static PSI_cond_info all_server_conds[]=
-@@ -11997,6 +12328,12 @@ static PSI_cond_info all_server_conds[]=
+@@ -11997,6 +12329,12 @@ static PSI_cond_info all_server_conds[]=
    { &key_cond_slave_parallel_pend_jobs, "Relay_log_info::pending_jobs_cond", 0, 0, PSI_DOCUMENT_ME},
    { &key_cond_slave_parallel_worker, "Worker_info::jobs_cond", 0, 0, PSI_DOCUMENT_ME},
    { &key_cond_mta_gaq, "Relay_log_info::mta_gaq_cond", 0, 0, PSI_DOCUMENT_ME},
@@ -5149,7 +5230,7 @@ index 3f94e768956..56eb1254522 100644
    { &key_COND_compress_gtid_table, "COND_compress_gtid_table", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_commit_order_manager_cond, "Commit_order_manager::m_workers.cond", 0, 0, PSI_DOCUMENT_ME},
 diff --git a/sql/mysqld.h b/sql/mysqld.h
-index 8b5a842b54b..f5b97743f5e 100644
+index 8b5a842b54b..7dd3f67e1f3 100644
 --- a/sql/mysqld.h
 +++ b/sql/mysqld.h
 @@ -180,6 +180,9 @@ extern MYSQL_PLUGIN_IMPORT std::atomic<int32>
@@ -5185,7 +5266,7 @@ index 8b5a842b54b..f5b97743f5e 100644
  #endif /* HAVE_PSI_INTERFACE */
  
  /*
-@@ -698,6 +717,55 @@ extern MYSQL_PLUGIN_IMPORT char pidfile_name[];
+@@ -698,6 +717,56 @@ extern MYSQL_PLUGIN_IMPORT char pidfile_name[];
  
  #define mysql_tmpdir (my_tmpdir(&mysql_tmpdir_list))
  
@@ -5205,6 +5286,7 @@ index 8b5a842b54b..f5b97743f5e 100644
 +extern bool opt_binlog_archive_expire_auto_purge;
 +extern ulong opt_binlog_archive_expire_seconds;
 +extern ulonglong opt_binlog_archive_period;
++extern ulong opt_binlog_archive_parallel_workers;
 +extern char *opt_consistent_snapshot_archive_dir;
 +extern bool opt_consistent_snapshot_persistent_on_objstore;
 +extern bool opt_initialize_use_objstore;
@@ -7836,7 +7918,7 @@ index 61828fe0164..0c4a3aaa94e 100644
          if (mysql_bin_log.rotate_and_purge(thd, true)) *write_to_binlog = -1;
        }
 diff --git a/sql/sql_show.cc b/sql/sql_show.cc
-index 64c61f060db..a249a5d6ac9 100644
+index 64c61f060db..b8b760aeaea 100644
 --- a/sql/sql_show.cc
 +++ b/sql/sql_show.cc
 @@ -72,6 +72,8 @@
@@ -7877,7 +7959,7 @@ index 64c61f060db..a249a5d6ac9 100644
      table->field[TMP_TABLE_COLUMNS_COLUMN_KEY]->store(
          (const char *)pos, strlen((const char *)pos), cs);
  
-@@ -4957,6 +4958,481 @@ static int hton_fill_schema_table(THD *thd, Table_ref *tables, Item *cond) {
+@@ -4957,6 +4958,501 @@ static int hton_fill_schema_table(THD *thd, Table_ref *tables, Item *cond) {
    return 0;
  }
  
@@ -7886,40 +7968,60 @@ index 64c61f060db..a249a5d6ac9 100644
 +  TABLE *table = tables->table;
 +  CHARSET_INFO *cs = system_charset_info;
 +  Binlog_archive *binlog_archive = Binlog_archive::get_instance();
-+  mysql_mutex_t *binlog_archive_lock =
-+      binlog_archive->get_binlog_archive_lock();
++  mysql_mutex_t *binlog_archive_lock = binlog_archive->get_binlog_archive_lock();
++  
 +  mysql_mutex_lock(binlog_archive_lock);
 +  if (!binlog_archive->is_thread_running()) {
 +    mysql_mutex_unlock(binlog_archive_lock);
-+    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-+           "binlog archive is not running");
++    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, "binlog archive is not running");
 +    return 0;
 +  }
 +  mysql_mutex_unlock(binlog_archive_lock);
-+  std::string mysql_binlog{};
-+  std::string archived_binlog{};
-+  my_off_t mysql_binlog_pos = 0;
-+  my_off_t mysql_binlog_write_pos = 0;
-+  my_off_t archived_binlog_pos = 0;
-+  my_off_t archived_binlog_write_pos = 0;
-+  uint64_t consensus_index = 0;
-+  uint64_t consensus_term = 0;
++
++  // New variables for additional information
++  uint64_t persisting_consensus_index;
++  uint64_t consensus_term;
++  std::string persisting_mysql_binlog;
++  my_off_t persisting_mysql_binlog_pos;
++  my_off_t persisting_mysql_binlog_write_pos; 
++  std::string persisting_binlog;
++  my_off_t persisting_binlog_pos;
++  my_off_t persisting_binlog_write_pos;
++  std::string persisted_binlog;
++  my_off_t persisted_binlog_pos;
++  uint64_t persisted_consensus_index;
++  std::string persisted_mysql_binlog;
++  my_off_t persisted_mysql_binlog_pos;
 +
 +  if (binlog_archive->show_binlog_archive_task_info(
-+          consensus_index, consensus_term, mysql_binlog, mysql_binlog_pos,
-+          mysql_binlog_write_pos, archived_binlog, archived_binlog_pos,
-+          archived_binlog_write_pos)) {
++          persisting_consensus_index, consensus_term,
++          persisting_mysql_binlog, persisting_mysql_binlog_pos,
++          persisting_mysql_binlog_write_pos,
++          persisting_binlog, persisting_binlog_pos,
++          persisting_binlog_write_pos, 
++          persisted_binlog, persisted_binlog_pos,
++          persisted_consensus_index,
++          persisted_mysql_binlog, persisted_mysql_binlog_pos)) {
 +    return 1;
 +  }
++
 +  restore_record(table, s->default_values);
-+  table->field[0]->store(consensus_index, true);
-+  table->field[1]->store(consensus_term, true);
-+  table->field[2]->store(mysql_binlog.c_str(), mysql_binlog.length(), cs);
-+  table->field[3]->store(mysql_binlog_pos, true);
-+  table->field[4]->store(mysql_binlog_write_pos, true);
-+  table->field[5]->store(archived_binlog.c_str(), archived_binlog.length(), cs);
-+  table->field[6]->store(archived_binlog_pos, true);
-+  table->field[7]->store(archived_binlog_write_pos, true);
++
++  // Store all values in the table fields
++  table->field[0]->store(consensus_term, true);
++  table->field[1]->store(persisted_consensus_index, true);
++  table->field[2]->store(persisted_binlog.c_str(), persisted_binlog.length(), cs);
++  table->field[3]->store(persisted_binlog_pos, true);
++  table->field[4]->store(persisted_mysql_binlog.c_str(), persisted_mysql_binlog.length(), cs);
++  table->field[5]->store(persisted_mysql_binlog_pos, true);
++  table->field[6]->store(persisting_consensus_index, true);
++  table->field[7]->store(persisting_mysql_binlog.c_str(), persisting_mysql_binlog.length(), cs);
++  table->field[8]->store(persisting_mysql_binlog_pos, true);
++  table->field[9]->store(persisting_mysql_binlog_write_pos, true);
++  table->field[10]->store(persisting_binlog.c_str(), persisting_binlog.length(), cs);
++  table->field[11]->store(persisting_binlog_pos, true);
++  table->field[12]->store(persisting_binlog_write_pos, true);
++
 +  if (schema_table_store_record(thd, table)) return 1;
 +
 +  return 0;
@@ -8359,19 +8461,24 @@ index 64c61f060db..a249a5d6ac9 100644
  ST_FIELD_INFO engines_fields_info[] = {
      {"ENGINE", 64, MYSQL_TYPE_STRING, 0, 0, "Engine", 0},
      {"SUPPORT", 8, MYSQL_TYPE_STRING, 0, 0, "Support", 0},
-@@ -5097,6 +5573,85 @@ ST_FIELD_INFO tmp_table_columns_fields_info[] = {
+@@ -5097,6 +5593,90 @@ ST_FIELD_INFO tmp_table_columns_fields_info[] = {
       MYSQL_TYPE_STRING, 0, 0, "Generation expression", 0},
      {nullptr, 0, MYSQL_TYPE_STRING, 0, 0, nullptr, 0}};
  
 +ST_FIELD_INFO binlog_persistent_task_info_fields_info[] = {
-+    {"LAST_RAFT_INDEX", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
 +    {"LAST_RAFT_TERM", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
-+    {"LAST_MYSQL_BINLOG", FN_REFLEN, MYSQL_TYPE_STRING, 0, 0, "Null", 0},
-+    {"LAST_MYSQL_BINLOG_PERSISTENT_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
-+    {"LAST_MYSQL_BINLOG_READ_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
-+    {"LAST_PERSISTENT_BINLOG", FN_REFLEN, MYSQL_TYPE_STRING, 0, 0, "Null", 0},
-+    {"LAST_PERSISTENT_BINLOG_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
-+    {"LAST_PERSISTENT_BINLOG_WRITE_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
++    {"LAST_PERSISTED_RAFT_INDEX", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
++    {"LAST_PERSISTED_BINLOG", FN_REFLEN, MYSQL_TYPE_STRING, 0, 0, "Null", 0},
++    {"LAST_PERSISTED_BINLOG_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
++    {"LAST_PERSISTED_MYSQL_BINLOG", FN_REFLEN, MYSQL_TYPE_STRING, 0, 0, "Null", 0},
++    {"LAST_PERSISTED_MYSQL_BINLOG_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
++    {"LAST_PERSISTING_RAFT_INDEX", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
++    {"LAST_PERSISTING_MYSQL_BINLOG", FN_REFLEN, MYSQL_TYPE_STRING, 0, 0, "Null", 0},
++    {"LAST_PERSISTING_MYSQL_BINLOG_PERSISTENT_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
++    {"LAST_PERSISTING_MYSQL_BINLOG_READ_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
++    {"LAST_PERSISTING_BINLOG", FN_REFLEN, MYSQL_TYPE_STRING, 0, 0, "Null", 0},
++    {"LAST_PERSISTING_BINLOG_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
++    {"LAST_PERSISTING_BINLOG_WRITE_POS", 21, MYSQL_TYPE_LONGLONG, 0, 0, "Null", 0},
 +    {nullptr, 0, MYSQL_TYPE_STRING, 0, 0, nullptr, 0}};
 +
 +ST_FIELD_INFO binlog_persistent_index_slice_fields_info[] = {
@@ -8445,7 +8552,7 @@ index 64c61f060db..a249a5d6ac9 100644
  /** For creating fields of information_schema.OPTIMIZER_TRACE */
  extern ST_FIELD_INFO optimizer_trace_info[];
  
-@@ -5135,6 +5690,29 @@ ST_SCHEMA_TABLE schema_tables[] = {
+@@ -5135,6 +5715,29 @@ ST_SCHEMA_TABLE schema_tables[] = {
       make_tmp_table_columns_format, get_schema_tmp_table_columns_record, true},
      {"TMP_TABLE_KEYS", tmp_table_keys_fields_info, show_temporary_tables,
       make_old_format, get_schema_tmp_table_keys_record, true},
@@ -8683,7 +8790,7 @@ index 6c3dd85db23..8c43a67cd52 100644
          | HASH_SYM
          | HISTOGRAM_SYM
 diff --git a/sql/sys_vars.cc b/sql/sys_vars.cc
-index b16cb1830e4..68eef470859 100644
+index b16cb1830e4..fbfb0faf93d 100644
 --- a/sql/sys_vars.cc
 +++ b/sql/sys_vars.cc
 @@ -93,11 +93,13 @@
@@ -8779,7 +8886,7 @@ index b16cb1830e4..68eef470859 100644
  
  static bool check_set_require_row_format(sys_var *, THD *thd, set_var *var) {
    /*
-@@ -7718,3 +7764,288 @@ static Sys_var_enum Sys_explain_format(
+@@ -7718,3 +7764,296 @@ static Sys_var_enum Sys_explain_format(
      SESSION_VAR(explain_format), CMD_LINE(OPT_ARG), explain_format_names,
      DEFAULT(static_cast<ulong>(Explain_format_type::TRADITIONAL)),
      NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr));
@@ -8831,6 +8938,14 @@ index b16cb1830e4..68eef470859 100644
 +    "binlog persist to object store at the given period milliseconds",
 +    GLOBAL_VAR(opt_binlog_archive_period), CMD_LINE(REQUIRED_ARG),
 +    VALID_RANGE(10, ULONG_MAX), DEFAULT(1000), BLOCK_SIZE(1));
++
++static Sys_var_ulong Sys_binlog_archive_parallel_workers(
++    "binlog_archive_parallel_workers",
++    "Number of worker threads for uploading binlog slice to "
++    "object store in parallel",
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_binlog_archive_parallel_workers),
++    CMD_LINE(REQUIRED_ARG), VALID_RANGE(1, MTS_MAX_WORKERS), DEFAULT(4),
++    BLOCK_SIZE(1));
 +
 +static Sys_var_bool Sys_snapshot_archive(
 +    "snapshot_archive",

--- a/sql/binlog_archive.cc
+++ b/sql/binlog_archive.cc
@@ -58,17 +58,26 @@ const float Binlog_archive::PACKET_SHRINK_FACTOR = 0.5;
 // Global binlog archive thread object
 static Binlog_archive mysql_binlog_archive;
 static my_thread_handle mysql_binlog_archive_pthd;
-static bool abort_binlog_archive = false;
 
-static mysql_mutex_t m_run_lock;
-static mysql_cond_t m_run_cond;
+static mysql_mutex_t m_binlog_archive_run_lock;
+static mysql_cond_t m_binlog_archive_run_cond;
 
 #ifdef HAVE_PSI_INTERFACE
 static PSI_thread_key THR_KEY_binlog_archive;
+static PSI_thread_key THR_KEY_binlog_archive_worker;
+static PSI_thread_key THR_KEY_binlog_archive_update_index_worker;
 static PSI_mutex_key PSI_binlog_archive_lock_key;
 static PSI_cond_key PSI_binlog_archive_cond_key;
+static PSI_mutex_key PSI_binlog_archive_worker_lock_key;
+static PSI_cond_key PSI_binlog_archive_worker_cond_key;
+static PSI_mutex_key PSI_binlog_archive_update_index_worker_lock_key;
+static PSI_cond_key PSI_binlog_archive_update_index_worker_cond_key;
 static PSI_mutex_key PSI_binlog_index_lock_key;
 static PSI_mutex_key PSI_binlog_rotate_lock_key;
+
+static PSI_mutex_key PSI_binlog_slice_lock_key;
+static PSI_cond_key PSI_binlog_slice_queue_cond_key;
+static PSI_cond_key PSI_binlog_slice_map_cond_key;
 
 /** The instrumentation key to use for opening the log file. */
 static PSI_file_key PSI_binlog_purge_archive_log_file_key;
@@ -81,10 +90,20 @@ static PSI_file_key PSI_binlog_archive_log_index_cache_key;
 
 static PSI_thread_info all_binlog_archive_threads[] = {
     {&THR_KEY_binlog_archive, "archive", "bin_arch", PSI_FLAG_AUTO_SEQNUM, 0,
-     PSI_DOCUMENT_ME}};
+     PSI_DOCUMENT_ME},
+    {&THR_KEY_binlog_archive_worker, "archive", "bin_arch_w",
+     PSI_FLAG_AUTO_SEQNUM, 0, PSI_DOCUMENT_ME},
+    {&THR_KEY_binlog_archive_update_index_worker, "archive", "bin_arch_i",
+     PSI_FLAG_AUTO_SEQNUM, 0, PSI_DOCUMENT_ME}};
 
 static PSI_mutex_info all_binlog_archive_mutex_info[] = {
     {&PSI_binlog_archive_lock_key, "binlog_archive::mutex", 0, 0,
+     PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_worker_lock_key, "binlog_archive::mutex", 0, 0,
+     PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_update_index_worker_lock_key, "binlog_archive::mutex",
+     0, 0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_slice_lock_key, "binlog_archive_index::mutex", 0, 0,
      PSI_DOCUMENT_ME},
     {&PSI_binlog_index_lock_key, "binlog_archive_index::mutex", 0, 0,
      PSI_DOCUMENT_ME},
@@ -93,6 +112,14 @@ static PSI_mutex_info all_binlog_archive_mutex_info[] = {
 
 static PSI_cond_info all_binlog_archive_cond_info[] = {
     {&PSI_binlog_archive_cond_key, "binlog_archive::condition", 0, 0,
+     PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_worker_cond_key, "binlog_archive::condition", 0, 0,
+     PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_update_index_worker_cond_key,
+     "binlog_archive::condition", 0, 0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_slice_queue_cond_key, "binlog_archive::condition", 0, 0,
+     PSI_DOCUMENT_ME},
+    {&PSI_binlog_slice_map_cond_key, "binlog_archive::condition", 0, 0,
      PSI_DOCUMENT_ME}};
 
 static PSI_file_info all_binlog_archive_files[] = {
@@ -106,6 +133,7 @@ static PSI_file_info all_binlog_archive_files[] = {
      0, PSI_DOCUMENT_ME}};
 #endif
 
+static bool copy_file(IO_CACHE *from, IO_CACHE *to, my_off_t offset);
 static void *mysql_binlog_archive_action(void *arg);
 static int compare_log_name(const char *log_1, const char *log_2);
 static bool remove_file(const std::string &file);
@@ -113,17 +141,366 @@ static void root_directory(std::string in, std::string *out, std::string *left);
 static bool recursive_create_dir(const std::string &dir,
                                  const std::string &root);
 static time_t calculate_auto_purge_lower_time_bound();
+static THD *set_thread_context();
+
+Binlog_archive_worker::Binlog_archive_worker(Binlog_archive *archive,
+                                             int worker_id)
+    : m_archive(archive),
+      m_worker_id(worker_id),
+      m_current_slice(),
+      m_thd(nullptr),
+      m_thd_state() {
+  mysql_mutex_init(PSI_binlog_archive_worker_lock_key, &m_worker_run_lock,
+                   MY_MUTEX_INIT_FAST);
+  mysql_cond_init(PSI_binlog_archive_worker_cond_key, &m_worker_run_cond);
+}
+
+Binlog_archive_worker::~Binlog_archive_worker() {
+  stop();
+  mysql_mutex_destroy(&m_worker_run_lock);
+  mysql_cond_destroy(&m_worker_run_cond);
+}
+
+/**
+ * @brief Start the binlog archive worker thread.
+ * @return true if the worker thread was successfully started, false otherwise.
+ */
+bool Binlog_archive_worker::start() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("start"));
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id, "starting");
+  mysql_mutex_lock(&m_worker_run_lock);
+  if (mysql_thread_create(THR_KEY_binlog_archive_worker, &m_thread,
+                          &connection_attrib, thread_launcher, (void *)this)) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id,
+           "start failed");
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return false;
+  }
+  thread_set_created();
+  while (is_thread_alive_not_running()) {
+    DBUG_PRINT("sleep", ("Waiting for binlog archive worker thread to start"));
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_worker_run_cond, &m_worker_run_lock, &abstime);
+  }
+  mysql_mutex_unlock(&m_worker_run_lock);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id, "started");
+  return true;
+}
+
+void Binlog_archive_worker::stop() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("stop"));
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id, "stopping");
+  mysql_mutex_lock(&m_worker_run_lock);
+  if (is_thread_dead()) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id, "stopped");
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return;
+  }
+  mysql_mutex_unlock(&m_worker_run_lock);
+  terminate_binlog_archive_worker_thread();
+  /* Wait until the thread is terminated. */
+  my_thread_join(&m_thread, nullptr);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id, "stop end");
+}
+
+/**
+ * @brief Binlog archive thread terminate worker thread.
+ *
+ * @return true if the worker thread was successfully terminated, false
+ * otherwise.
+ */
+int Binlog_archive_worker::terminate_binlog_archive_worker_thread() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("terminate_binlog_archive_worker_thread"));
+  mysql_mutex_lock(&m_worker_run_lock);
+  while (m_thd_state.is_thread_alive()) {
+    DBUG_PRINT("sleep", ("Waiting for binlog archive thread to stop"));
+    if (m_thd_state.is_initialized()) {
+      mysql_mutex_lock(&m_thd->LOCK_thd_data);
+      m_thd->awake(THD::KILL_CONNECTION);
+      mysql_mutex_unlock(&m_thd->LOCK_thd_data);
+    }
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_worker_run_cond, &m_worker_run_lock, &abstime);
+  }
+  assert(m_thd_state.is_thread_dead());
+  mysql_mutex_unlock(&m_worker_run_lock);
+  return 0;
+}
+
+/**
+ * @brief Worker thread function for persisting binlog slices to the object
+ * store.
+ * @return void* Thread return value (nullptr)
+ */
+void *Binlog_archive_worker::worker_thread() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("worker_thread"));
+  Binlog_archive *archive = m_archive;
+
+  m_thd = set_thread_context();
+
+  mysql_mutex_lock(&m_worker_run_lock);
+  m_thd_state.set_running();
+  mysql_cond_broadcast(&m_worker_run_cond);
+  mysql_mutex_unlock(&m_worker_run_lock);
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id,
+         "thread running");
+  while (true) {
+    uint32_t retry = 5;
+    Binlog_expected_slice slice;
+    bool is_slice_persisted = false;
+
+    mysql_mutex_lock(&archive->m_slice_mutex);
+    // Wait for the slice to be available.
+    m_thd->ENTER_COND(&archive->m_queue_cond, &archive->m_slice_mutex, nullptr,
+                      nullptr);
+    while (archive->m_expected_slice_queue.empty() &&
+           !unlikely(m_thd->killed)) {
+      // Wait for signal from the binlog archive thread that the new expected
+      // slice is added to the queue. Or the worker thread is killed.
+      mysql_cond_wait(&archive->m_queue_cond, &archive->m_slice_mutex);
+    }
+    // When only the queue is empty and the worker thread is killed, exit.
+    // If the queue is not empty, the worker thread will continue to process
+    // the slice until the queue is empty.
+    if (archive->m_expected_slice_queue.empty() && unlikely(m_thd->killed)) {
+      mysql_mutex_unlock(&archive->m_slice_mutex);
+      m_thd->EXIT_COND(nullptr);
+      break;
+    }
+    // Get the slice from the queue.
+    archive->m_expected_slice_queue.de_queue(&slice);
+    mysql_mutex_unlock(&archive->m_slice_mutex);
+    m_thd->EXIT_COND(nullptr);
+    // Signal the binlog archive thread that wait, because the slice queue
+    // is full.
+    mysql_cond_signal(&archive->m_queue_cond);
+    m_current_slice = slice;
+
+    // Persist the slice to the object store.
+    while (retry-- > 0) {
+      bool error = false;
+      DBUG_EXECUTE_IF("fault_injection_put_slice_to_objstore", {
+        LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id,
+               "fault_injection_put_slice_to_objstore");
+        error = true;
+      });
+      if (error) break;
+
+      std::string err_msg;
+      objstore::Status ss = m_archive->get_objstore()->put_object(
+          std::string_view(opt_objstore_bucket), slice.m_slice_keyid,
+          std::string_view(slice.slice_data_cache), false);
+      err_msg.append(" put slice object ");
+      err_msg.append(slice.m_slice_keyid);
+      err_msg.append(" size=");
+      err_msg.append(std::to_string(slice.m_slice_bytes_written));
+      err_msg.append(" ");
+      err_msg.append(std::to_string(slice.m_file_seq));
+      err_msg.append("/");
+      err_msg.append(std::to_string(slice.m_slice_seq));
+
+      if (!ss.is_succ()) {
+        err_msg.append(ss.error_message());
+        LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id,
+               err_msg.c_str());
+        my_sleep(1000);
+        continue;
+      }
+      is_slice_persisted = true;
+      LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id,
+             err_msg.c_str());
+      break;
+    }
+    // Notify the binlog archive thread that the slice has been persisted.
+    // After dequeuing the slice, m_slice_mutex is unlocked. So maybe the slice
+    // map is reinited, so we need to check m_slice_queue_and_map_initted before
+    // notify the slice persisted.
+    m_archive->notify_slice_persisted(slice, is_slice_persisted);
+  }
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id, "thread end");
+
+  mysql_mutex_lock(&m_worker_run_lock);
+  delete m_thd;
+  m_thd = nullptr;
+  m_thd_state.set_terminated();
+  mysql_cond_broadcast(&m_worker_run_cond);
+  mysql_mutex_unlock(&m_worker_run_lock);
+  my_thread_end();
+  my_thread_exit(nullptr);
+}
+
+Binlog_archive_update_index_worker::Binlog_archive_update_index_worker(
+    Binlog_archive *archive)
+    : m_archive(archive),
+      m_thd(nullptr),
+      m_thd_state(),
+      atomic_update_index_failed(false) {
+  mysql_mutex_init(PSI_binlog_archive_update_index_worker_lock_key,
+                   &m_worker_run_lock, MY_MUTEX_INIT_FAST);
+  mysql_cond_init(PSI_binlog_archive_update_index_worker_cond_key,
+                  &m_worker_run_cond);
+}
+
+Binlog_archive_update_index_worker::~Binlog_archive_update_index_worker() {
+  stop();
+  mysql_mutex_destroy(&m_worker_run_lock);
+  mysql_cond_destroy(&m_worker_run_cond);
+}
+
+/**
+ * @brief Start the binlog archive worker thread.
+ * @return true if the worker thread was successfully started, false otherwise.
+ */
+bool Binlog_archive_update_index_worker::start() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("start"));
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG, "starting");
+  mysql_mutex_lock(&m_worker_run_lock);
+  if (mysql_thread_create(THR_KEY_binlog_archive_update_index_worker, &m_thread,
+                          &connection_attrib, thread_launcher, (void *)this)) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG,
+           "start failed");
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return false;
+  }
+  thread_set_created();
+  while (is_thread_alive_not_running()) {
+    DBUG_PRINT("sleep", ("Waiting for binlog archive worker thread to start"));
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_worker_run_cond, &m_worker_run_lock, &abstime);
+  }
+  mysql_mutex_unlock(&m_worker_run_lock);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG, "started");
+  return true;
+}
+
+void Binlog_archive_update_index_worker::stop() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("stop"));
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG, "stopping");
+  mysql_mutex_lock(&m_worker_run_lock);
+  if (is_thread_dead()) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG, "stopped");
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return;
+  }
+  mysql_mutex_unlock(&m_worker_run_lock);
+  terminate_binlog_archive_update_index_worker();
+  /* Wait until the thread is terminated. */
+  my_thread_join(&m_thread, nullptr);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG, "stop end");
+}
+
+/**
+ * @brief Binlog archive thread terminate worker thread.
+ *
+ * @return true if the worker thread was successfully terminated, false
+ * otherwise.
+ */
+int Binlog_archive_update_index_worker::
+    terminate_binlog_archive_update_index_worker() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("terminate_binlog_archive_update_index_worker"));
+  mysql_mutex_lock(&m_worker_run_lock);
+  while (m_thd_state.is_thread_alive()) {
+    DBUG_PRINT("sleep",
+               ("Waiting for binlog archive update index worker to stop"));
+    if (m_thd_state.is_initialized()) {
+      mysql_mutex_lock(&m_thd->LOCK_thd_data);
+      m_thd->awake(THD::KILL_CONNECTION);
+      mysql_mutex_unlock(&m_thd->LOCK_thd_data);
+    }
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_worker_run_cond, &m_worker_run_lock, &abstime);
+  }
+  assert(m_thd_state.is_thread_dead());
+  mysql_mutex_unlock(&m_worker_run_lock);
+  return 0;
+}
+
+void *Binlog_archive_update_index_worker::worker_thread() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("worker_thread"));
+  Binlog_archive *archive = m_archive;
+
+  m_thd = set_thread_context();
+  mysql_mutex_lock(&m_worker_run_lock);
+  m_thd_state.set_running();
+  mysql_cond_broadcast(&m_worker_run_cond);
+  mysql_mutex_unlock(&m_worker_run_lock);
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG,
+         "thread running");
+  while (true) {
+    mysql_mutex_lock(&archive->m_slice_mutex);
+    // Wait for the slice to be available.
+    m_thd->ENTER_COND(&archive->m_map_cond, &archive->m_slice_mutex, nullptr,
+                      nullptr);
+    while (((archive->m_slice_status_map.empty() || update_index_is_failed()) &&
+            !unlikely(m_thd->killed))) {
+      // Wait for signal from the binlog archive thread that the new expected
+      // slice is added to the queue. Or the worker thread is killed.
+      // If the update index is failed, wait for the binlog archive thread to
+      // reset the flag and clear the map.
+      mysql_cond_wait(&archive->m_map_cond, &archive->m_slice_mutex);
+    }
+    // If update index worker is killed, need process the left slices in the
+    // map until the map is empty.
+    // Before the update index worker is killed, the binlog archive worker must
+    // have been killed first. This is ensured by the binlog archive main
+    // thread.
+    if ((archive->m_slice_status_map.empty() || update_index_is_failed()) &&
+        unlikely(m_thd->killed)) {
+      mysql_mutex_unlock(&archive->m_slice_mutex);
+      m_thd->EXIT_COND(nullptr);
+      break;
+    }
+    mysql_mutex_unlock(&archive->m_slice_mutex);
+    m_thd->EXIT_COND(nullptr);
+
+    if (!archive->update_index_file(true)) {
+      set_update_index_failed(true);
+      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG,
+             "update index failed");
+    }
+  }
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG, "thread end");
+
+  mysql_mutex_lock(&m_worker_run_lock);
+  delete m_thd;
+  m_thd = nullptr;
+  m_thd_state.set_terminated();
+  mysql_cond_broadcast(&m_worker_run_cond);
+  mysql_mutex_unlock(&m_worker_run_lock);
+  my_thread_end();
+  my_thread_exit(nullptr);
+}
 
 /**
  * @brief Creates a binlog archive object and starts the binlog archive thread.
+ * @return int 0 if the binlog archive thread was successfully started, 1
+ * otherwise.
  */
 int start_binlog_archive() {
   DBUG_TRACE;
   DBUG_PRINT("info", ("start_binlog_archive"));
   // Check if the binlog is enabled.
   if (!opt_bin_log) {
-    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_STARTUP,
-           "need enable binlog mode");
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_STARTUP, "need enable binlog mode");
     return 0;
   }
   // Check if the binlog archive is enabled.
@@ -238,14 +615,13 @@ int start_binlog_archive() {
   }
   mysql_binlog_archive.set_objstore(objstore);
 
-  mysql_mutex_lock(&m_run_lock);
-  abort_binlog_archive = false;
+  mysql_mutex_lock(&m_binlog_archive_run_lock);
   if (mysql_thread_create(THR_KEY_binlog_archive, &mysql_binlog_archive_pthd,
                           &connection_attrib, mysql_binlog_archive_action,
                           (void *)&mysql_binlog_archive)) {
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_STARTUP,
            "Failed to create binlog archive thread");
-    mysql_mutex_unlock(&m_run_lock);
+    mysql_mutex_unlock(&m_binlog_archive_run_lock);
     return 1;
   }
 
@@ -255,9 +631,10 @@ int start_binlog_archive() {
     DBUG_PRINT("sleep", ("Waiting for binlog archive thread to start"));
     struct timespec abstime;
     set_timespec(&abstime, 1);
-    mysql_cond_timedwait(&m_run_cond, &m_run_lock, &abstime);
+    mysql_cond_timedwait(&m_binlog_archive_run_cond, &m_binlog_archive_run_lock,
+                         &abstime);
   }
-  mysql_mutex_unlock(&m_run_lock);
+  mysql_mutex_unlock(&m_binlog_archive_run_lock);
   return 0;
 }
 
@@ -265,21 +642,21 @@ int start_binlog_archive() {
  * @brief stop the binlog archive thread.
  * @note must stop consistent snapshot thread, before stop the binlog archive
  * thread. Consistent snapshot thread depends on the binlog archive thread.
+ * @return void
  */
 void stop_binlog_archive() {
   DBUG_TRACE;
   DBUG_PRINT("info", ("stop_binlog_archive"));
-  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-         "stop binlog archive begin.");
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, "stop binlog archive begin");
 
-  mysql_mutex_lock(&m_run_lock);
+  mysql_mutex_lock(&m_binlog_archive_run_lock);
   if (mysql_binlog_archive.is_thread_dead()) {
     LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "binlog archive stopped already.");
-    mysql_mutex_unlock(&m_run_lock);
+           "binlog archive stopped already");
+    mysql_mutex_unlock(&m_binlog_archive_run_lock);
     return;
   }
-  mysql_mutex_unlock(&m_run_lock);
+  mysql_mutex_unlock(&m_binlog_archive_run_lock);
   mysql_binlog_archive.terminate_binlog_archive_thread();
   /* Wait until the thread is terminated. */
   my_thread_join(&mysql_binlog_archive_pthd, nullptr);
@@ -287,7 +664,7 @@ void stop_binlog_archive() {
     objstore::destroy_object_store(mysql_binlog_archive.get_objstore());
     mysql_binlog_archive.set_objstore(nullptr);
   }
-  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, "stop binlog archive end.");
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, "stop binlog archive end");
 }
 
 /**
@@ -324,7 +701,9 @@ class Binlog_archive::Event_allocator {
  * @brief Constructs a Binlog_archive object.
  */
 Binlog_archive::Binlog_archive()
-    : m_thd(nullptr),
+    : m_expected_slice_queue(),
+      m_slice_status_map(),
+      m_thd(nullptr),
       m_thd_state(),
       m_description_event(BINLOG_VERSION, ::server_version),
       binlog_objstore(nullptr),
@@ -334,7 +713,6 @@ Binlog_archive::Binlog_archive()
       m_index_file(),
       m_crash_safe_index_file(),
       m_purge_index_file() {
-  m_consensus_is_leader = false;
   m_consensus_term = 0;
   m_mysql_binlog_first_file = true;
   m_binlog_archive_last_index_number = 0;
@@ -364,6 +742,17 @@ Binlog_archive::Binlog_archive()
   m_index_file_name[0] = '\0';
   m_crash_safe_index_local_file_name[0] = '\0';
   m_purge_index_file_name[0] = '\0';
+
+  m_update_index_worker = nullptr;
+  m_workers = nullptr;
+  m_current_file_seq = 0;
+  m_slice_queue_and_map_initted = false;
+  m_persisted_binlog_file_name[0] = '\0';
+  m_persisted_mysql_binlog_file_name[0] = '\0';
+  m_persisted_mysql_binlog_last_event_end_pos = 0;
+  m_persisted_binlog_last_event_end_pos = 0;
+  m_persisted_slice_end_consensus_index = 0;
+  m_persisted_binlog_previouse_consensus_index = 0;
 }
 
 /**
@@ -394,24 +783,30 @@ void Binlog_archive::init_pthread_object() {
 
 #endif
 
-  mysql_mutex_init(PSI_binlog_archive_lock_key, &m_run_lock,
-                   MY_MUTEX_INIT_FAST);
-  mysql_cond_init(PSI_binlog_archive_cond_key, &m_run_cond);
-
-  mysql_mutex_init(PSI_binlog_index_lock_key, &m_index_lock,
+  mysql_cond_init(PSI_binlog_archive_cond_key, &m_binlog_archive_run_cond);
+  mysql_mutex_init(PSI_binlog_archive_lock_key, &m_binlog_archive_run_lock,
                    MY_MUTEX_INIT_FAST);
   mysql_mutex_init(PSI_binlog_rotate_lock_key, &m_rotate_lock,
                    MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(PSI_binlog_index_lock_key, &m_index_lock,
+                   MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(PSI_binlog_slice_lock_key, &m_slice_mutex,
+                   MY_MUTEX_INIT_FAST);
+  mysql_cond_init(PSI_binlog_slice_queue_cond_key, &m_queue_cond);
+  mysql_cond_init(PSI_binlog_slice_map_cond_key, &m_map_cond);
 }
 
 /**
  * @brief Cleans up any resources used by the binlog archive.
  */
 void Binlog_archive::deinit_pthread_object() {
+  mysql_cond_destroy(&m_map_cond);
+  mysql_cond_destroy(&m_queue_cond);
+  mysql_mutex_destroy(&m_slice_mutex);
   mysql_mutex_destroy(&m_index_lock);
   mysql_mutex_destroy(&m_rotate_lock);
-  mysql_mutex_destroy(&m_run_lock);
-  mysql_cond_destroy(&m_run_cond);
+  mysql_mutex_destroy(&m_binlog_archive_run_lock);
+  mysql_cond_destroy(&m_binlog_archive_run_cond);
 }
 
 /**
@@ -420,7 +815,14 @@ void Binlog_archive::deinit_pthread_object() {
  */
 Binlog_archive *Binlog_archive::get_instance() { return &mysql_binlog_archive; }
 
-mysql_mutex_t *Binlog_archive::get_binlog_archive_lock() { return &m_run_lock; }
+/**
+ * @brief Returns the binlog archive lock.
+ *
+ * @return mysql_mutex_t*
+ */
+mysql_mutex_t *Binlog_archive::get_binlog_archive_lock() {
+  return &m_binlog_archive_run_lock;
+}
 
 /**
  * @brief Terminate the binlog archive thread.
@@ -430,8 +832,7 @@ mysql_mutex_t *Binlog_archive::get_binlog_archive_lock() { return &m_run_lock; }
 int Binlog_archive::terminate_binlog_archive_thread() {
   DBUG_TRACE;
   DBUG_PRINT("info", ("terminate_binlog_archive_thread"));
-  mysql_mutex_lock(&m_run_lock);
-  abort_binlog_archive = true;
+  mysql_mutex_lock(&m_binlog_archive_run_lock);
   while (m_thd_state.is_thread_alive()) {
     DBUG_PRINT("sleep", ("Waiting for binlog archive thread to stop"));
     if (m_thd_state.is_initialized()) {
@@ -441,10 +842,11 @@ int Binlog_archive::terminate_binlog_archive_thread() {
     }
     struct timespec abstime;
     set_timespec(&abstime, 1);
-    mysql_cond_timedwait(&m_run_cond, &m_run_lock, &abstime);
+    mysql_cond_timedwait(&m_binlog_archive_run_cond, &m_binlog_archive_run_lock,
+                         &abstime);
   }
   assert(m_thd_state.is_thread_dead());
-  mysql_mutex_unlock(&m_run_lock);
+  mysql_mutex_unlock(&m_binlog_archive_run_lock);
   return 0;
 }
 
@@ -452,7 +854,7 @@ int Binlog_archive::terminate_binlog_archive_thread() {
  * @brief Initializes the THD context.
  *
  */
-void Binlog_archive::set_thread_context() {
+static THD *set_thread_context() {
   THD *thd = new THD;
   my_thread_init();
   thd->set_new_thread_id();
@@ -463,32 +865,48 @@ void Binlog_archive::set_thread_context() {
   /* No privilege check needed */
   thd->security_context()->skip_grants();
   // Global_THD_manager::get_instance()->add_thd(thd);
-  m_thd = thd;
+  return thd;
 }
 
+/**
+ * @brief Check if a string represents a valid number.
+ * @param str String to check
+ * @param res Pointer to store the parsed number (if not NULL)
+ * @param allow_wildcards Whether to allow wildcard chars (* and ?) in the
+ * number
+ * @return true if string represents a valid number
+ * @return false if string is not a valid number
+ * @note Handles positive/negative integers and decimals
+ */
 static bool is_number(const char *str, ulonglong *res, bool allow_wildcards) {
   DBUG_TRACE;
   int flag = 0;
   const char *start = str;
 
+  // Skip leading spaces
   while (*str++ == ' ')
     ;
+  // Handle optional sign
   if (*--str == '-' || *str == '+') str++;
+  // Process digits and wildcards before decimal
   while (my_isdigit(files_charset_info, *str) ||
          (allow_wildcards && (*str == wild_many || *str == wild_one))) {
     flag = 1;
     str++;
   }
+  // Handle decimal point and trailing digits/wildcards
   if (*str == '.') {
     for (str++; my_isdigit(files_charset_info, *str) ||
                 (allow_wildcards && (*str == wild_many || *str == wild_one));
          str++, flag = 1)
       ;
   }
+  // Invalid if any chars remain or no digits found
   if (*str != 0 || flag == 0) return false;
+  // Store result if pointer provided
   if (res) *res = atol(start);
   return true; /* Number ok */
-} /* is_number */
+}
 
 /**
  * @brief Runs the binlog archiving process.
@@ -500,12 +918,12 @@ void Binlog_archive::run() {
   LOG_ARCHIVED_INFO log_info{};
   int error = 1;
 
-  set_thread_context();
+  m_thd = set_thread_context();
 
-  mysql_mutex_lock(&m_run_lock);
+  mysql_mutex_lock(&m_binlog_archive_run_lock);
   m_thd_state.set_initialized();
-  mysql_cond_broadcast(&m_run_cond);
-  mysql_mutex_unlock(&m_run_lock);
+  mysql_cond_broadcast(&m_binlog_archive_run_cond);
+  mysql_mutex_unlock(&m_binlog_archive_run_lock);
 
   strmake(m_mysql_archive_dir, opt_binlog_archive_dir,
           sizeof(m_mysql_archive_dir) - 1);
@@ -529,10 +947,20 @@ void Binlog_archive::run() {
   strmake(m_binlog_archive_dir, binlog_objectstore_path.c_str(),
           sizeof(m_binlog_archive_dir) - 1);
 
-  mysql_mutex_lock(&m_run_lock);
+  mysql_mutex_lock(&m_binlog_archive_run_lock);
   m_thd_state.set_running();
-  mysql_cond_broadcast(&m_run_cond);
-  mysql_mutex_unlock(&m_run_lock);
+  mysql_cond_broadcast(&m_binlog_archive_run_cond);
+  mysql_mutex_unlock(&m_binlog_archive_run_lock);
+
+  assert(!m_expected_slice_queue.inited_queue);
+  m_expected_slice_queue.avail = 0;
+  m_expected_slice_queue.entry = 0;
+  m_expected_slice_queue.len = 0;
+  m_expected_slice_queue.capacity = 4 * opt_binlog_archive_parallel_workers;
+  m_expected_slice_queue.inited_queue = true;
+  Binlog_expected_slice slice;
+  m_expected_slice_queue.m_Q.resize(m_expected_slice_queue.capacity, slice);
+  assert(m_expected_slice_queue.m_Q.size() == m_expected_slice_queue.capacity);
 
   err_msg.assign("Binlog archive thread running");
 #ifdef WESQL_CLUSTER
@@ -540,6 +968,25 @@ void Binlog_archive::run() {
                                                      : " in Data mode");
 #endif
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+
+  // create binlog archive update index worker thread.
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+         "create binlog archive update index worker");
+  m_update_index_worker = new Binlog_archive_update_index_worker(this);
+  if (!m_update_index_worker->start()) goto end;
+
+  // create binlog archive worker thread.
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, "create binlog archive worker");
+  m_workers = static_cast<Binlog_archive_worker **>(my_malloc(
+      PSI_NOT_INSTRUMENTED,
+      opt_binlog_archive_parallel_workers * sizeof(Binlog_archive_worker *),
+      MYF(MY_WME)));
+  if (!m_workers) goto end;
+  for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
+    Binlog_archive_worker *worker = new Binlog_archive_worker(this, i);
+    m_workers[i] = worker;
+    if (!worker->start()) goto end;
+  }
 
   for (;;) {
     my_off_t last_binlog_slice_max_num = 0;
@@ -551,15 +998,15 @@ void Binlog_archive::run() {
     uint64_t consensus_term = 0;
     char mysql_start_binlog[FN_REFLEN + 1] = {0};
     char last_binlog_file_name[FN_REFLEN + 1] = {0};
-    mysql_mutex_lock(&m_run_lock);
-    if (abort_binlog_archive) {
+    mysql_mutex_lock(&m_binlog_archive_run_lock);
+    if (unlikely(m_thd->killed)) {
       err_msg.assign(" persist end consensus index=");
       err_msg.append(std::to_string(m_slice_end_consensus_index));
       LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
-      mysql_mutex_unlock(&m_run_lock);
+      mysql_mutex_unlock(&m_binlog_archive_run_lock);
       break;
     }
-    mysql_mutex_unlock(&m_run_lock);
+    mysql_mutex_unlock(&m_binlog_archive_run_lock);
     if (m_thd == nullptr || m_thd->killed) {
       err_msg.assign(" persist end consensus index=");
       err_msg.append(std::to_string(m_slice_end_consensus_index));
@@ -570,19 +1017,20 @@ void Binlog_archive::run() {
 
 #ifdef WESQL_CLUSTER
     // Check whether consensus role is leader and fetch leader term
-    if (!is_consensus_replication_state_leader(consensus_term)) {
+    if (DBUG_EVALUATE_IF("fault_injection_binlog_archive_running", true,
+                         false) ||
+        !is_consensus_replication_state_leader(consensus_term)) {
       struct timespec abstime;
       set_timespec(&abstime, 1);
-      mysql_mutex_lock(&m_run_lock);
-      m_consensus_is_leader = false;
+      mysql_mutex_lock(&m_binlog_archive_run_lock);
       // When demoted to a non-Leader role, the previous Leader role's consensus
       // term remains unchanged, making it easier to query the binlog persistent
       // view. m_consensus_term = 0;
-      error = mysql_cond_timedwait(&m_run_cond, &m_run_lock, &abstime);
-      mysql_mutex_unlock(&m_run_lock);
+      error = mysql_cond_timedwait(&m_binlog_archive_run_cond,
+                                   &m_binlog_archive_run_lock, &abstime);
+      mysql_mutex_unlock(&m_binlog_archive_run_lock);
       continue;
     }
-    m_consensus_is_leader = true;
     m_consensus_term = consensus_term;
 #endif
     sprintf(m_index_file_name, "%s" BINLOG_ARCHIVE_CONSENSUS_TERM_EXT "%s",
@@ -612,7 +1060,7 @@ void Binlog_archive::run() {
         close_index_file();
         mysql_mutex_unlock(&m_index_lock);
         LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-               "Find binlog from persistent binlog index failed.");
+               "Find binlog from persistent binlog index failed");
         break;
       }
       my_off_t number = 0;
@@ -633,7 +1081,7 @@ void Binlog_archive::run() {
       close_index_file();
       mysql_mutex_unlock(&m_index_lock);
       LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-             "Failed IO to find binlog from archive binlog index file.");
+             "Failed IO to find binlog from archive binlog index file");
       break;
     }
     mysql_mutex_unlock(&m_index_lock);
@@ -736,8 +1184,33 @@ void Binlog_archive::run() {
     // init in archive_init()
     m_mysql_binlog_file_name[0] = '\0';
     m_binlog_archive_file_name[0] = '\0';
+    m_current_file_seq = -1;
+    m_current_slice_seq = -1;
 
+    // init last persisted binlog
+    strmake(m_persisted_binlog_file_name, last_binlog_file_name,
+            sizeof(m_persisted_binlog_file_name) - 1);
+    strmake(m_persisted_mysql_binlog_file_name, mysql_start_binlog,
+            sizeof(m_persisted_mysql_binlog_file_name) - 1);
+    m_persisted_mysql_binlog_last_event_end_pos = m_mysql_binlog_start_pos;
+    m_persisted_binlog_last_event_end_pos = last_binlog_slice_max_num;
+    m_persisted_slice_end_consensus_index = slice_end_consensus_index;
+    m_persisted_binlog_previouse_consensus_index = previous_consensus_index;
     mysql_mutex_unlock(&m_rotate_lock);
+
+    // Before starting the binlog archive each time, the binlog slice queue and
+    // map must be cleared.
+    mysql_mutex_lock(&m_slice_mutex);
+    if (!m_expected_slice_queue.empty()) {
+      Binlog_expected_slice slice_empty;
+      m_expected_slice_queue.de_queue(&slice_empty);
+    }
+    assert(m_expected_slice_queue.len == 0);
+
+    m_slice_status_map.clear();
+    m_slice_queue_and_map_initted = false;
+    m_update_index_worker->set_update_index_failed(false);
+    mysql_mutex_unlock(&m_slice_mutex);
 
     // The binlog archive only stops in the event of an error, such
     // as when the thread is killed, aborted, consensus role or term changed, or
@@ -745,7 +1218,8 @@ void Binlog_archive::run() {
     // aborted, the binlog archive thread must exit. For other errors, will
     // retry binlog archiving after waiting for a period of time.
     if (archive_binlogs()) {
-      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, "persistent binlog abort");
+      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+             "binlog archive persistent abort");
     }
 
     // persist last binlog slice to object store.
@@ -762,7 +1236,6 @@ void Binlog_archive::run() {
     // `information_schema.BINLOG_PERSISTENT_TASK_INFO` with the `match_index`
     // obtained from `information_schema.wesql_cluster_global`.
     rotate_binlog_slice(0, true);
-
     mysql_mutex_lock(&m_rotate_lock);
     // If previous archived binlog slice is not closed, close it.
     m_slice_cache.clear();
@@ -784,22 +1257,43 @@ void Binlog_archive::run() {
     // after waiting for a period of time
     struct timespec abstime;
     set_timespec(&abstime, 1);
-    mysql_mutex_lock(&m_run_lock);
-    error = mysql_cond_timedwait(&m_run_cond, &m_run_lock, &abstime);
-    mysql_mutex_unlock(&m_run_lock);
+    mysql_mutex_lock(&m_binlog_archive_run_lock);
+    error = mysql_cond_timedwait(&m_binlog_archive_run_cond,
+                                 &m_binlog_archive_run_lock, &abstime);
+    mysql_mutex_unlock(&m_binlog_archive_run_lock);
   }
 
+end:
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, "Binlog archive thread end");
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, "stop binlog archive worker");
+  for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
+    Binlog_archive_worker *worker = m_workers[i];
+    delete worker;
+  }
+  if (m_workers) {
+    my_free(m_workers);
+    m_workers = nullptr;
+  }
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+         "stop binlog archive update index worker");
+  // Finally, stop the binlog archive update index worker thread.
+  // Wait for all persisted binlog slices to be persisted to the object store
+  // and the binlog index to be updated.
+  if (m_update_index_worker) {
+    delete m_update_index_worker;
+    m_update_index_worker = nullptr;
+  }
   // Free new Item_***.
   m_thd->free_items();
   m_thd->release_resources();
-  mysql_mutex_lock(&m_run_lock);
+  mysql_mutex_lock(&m_binlog_archive_run_lock);
   delete m_thd;
   m_thd = nullptr;
-  abort_binlog_archive = true;
   m_thd_state.set_terminated();
-  mysql_cond_broadcast(&m_run_cond);
-  mysql_mutex_unlock(&m_run_lock);
+  mysql_cond_broadcast(&m_binlog_archive_run_cond);
+  mysql_mutex_unlock(&m_binlog_archive_run_lock);
   my_thread_end();
   my_thread_exit(nullptr);
 }
@@ -900,6 +1394,12 @@ bool Binlog_archive::consensus_leader_is_changed() {
 #endif
   return false;
 }
+
+/**
+ * @brief Archives the MySQL binlog files.
+ *
+ * @return int
+ */
 int Binlog_archive::archive_binlogs() {
   DBUG_TRACE;
   DBUG_PRINT("info", ("archive_binlogs"));
@@ -946,7 +1446,7 @@ int Binlog_archive::archive_binlogs() {
                                         log_file, false)) {
         LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
                "mysql binary log is not open and failed to open index file "
-               "to retrieve next file.");
+               "to retrieve next file");
         mysql_bin_log.unlock_index();
         ret = 1;
         break;
@@ -1079,6 +1579,13 @@ int Binlog_archive::read_format_description_event(File_reader &reader) {
   return 0;
 }
 
+/**
+ * @brief Archive events from the binlog file.
+ *
+ * @param reader
+ * @param end_pos
+ * @return int
+ */
 int Binlog_archive::archive_events(File_reader &reader, my_off_t end_pos) {
   DBUG_TRACE;
   DBUG_PRINT("info", ("archive_events"));
@@ -1143,8 +1650,8 @@ int Binlog_archive::archive_events(File_reader &reader, my_off_t end_pos) {
 }
 
 /**
- * @brief Write an binlog event from log_file with log_pos to the archive
- * binlog cache.
+ * @brief Write an binlog event from binlog with log_pos to the archive
+ * binlog slice local cache.
  *
  * @param log_file mysql binlog of the read
  * @param log_pos mysql binlog end position of the read
@@ -1190,7 +1697,8 @@ int Binlog_archive::archive_event(File_reader &reader, uchar *event_ptr,
     // When MySQL switches to a new binlog, the persistent binlog should also
     // follow suit. Before switching to a new persistent binlog, the remaining
     // events of the previous binlog need to be persisted.
-    if (rotate_binlog_slice(m_mysql_binlog_write_last_event_end_pos, false)) {
+    if (rotate_binlog_slice(m_mysql_binlog_write_last_event_end_pos, false) ==
+        1) {
       error = 1;
       goto err_slice;
     }
@@ -1323,7 +1831,8 @@ int Binlog_archive::archive_event(File_reader &reader, uchar *event_ptr,
     ulonglong now = my_milli_time();
     if ((m_slice_bytes_written >= opt_binlog_archive_slice_max_size) ||
         ((now - m_slice_create_ts) >= opt_binlog_archive_period)) {
-      if (rotate_binlog_slice(m_mysql_binlog_write_last_event_end_pos, false)) {
+      if (rotate_binlog_slice(m_mysql_binlog_write_last_event_end_pos, false) ==
+          1) {
         error = 1;
         goto err_slice;
       }
@@ -1350,6 +1859,13 @@ inline void Binlog_archive::calc_event_checksum(uchar *event_ptr,
   int4store(event_ptr + event_len - BINLOG_CHECKSUM_LEN, crc);
 }
 
+/**
+ * @brief Merge binlog slices to a single binlog file.
+ *
+ * @param log_name
+ * @param to_binlog_file
+ * @return int
+ */
 int Binlog_archive::merge_slice_to_binlog_file(const char *log_name,
                                                const char *to_binlog_file) {
   DBUG_TRACE;
@@ -1485,6 +2001,13 @@ int Binlog_archive::new_persistent_binlog_slice_key(const char *binlog,
   return 0;
 }
 
+/**
+ * @brief Check if stop waiting for mysql binlog update.
+ *
+ * @param log_pos wait for mysql binlog update position
+ * @return 0 if stop waiting for mysql binlog update, 1 if continue waiting,
+ * -1 if wait for mysql binlog update is failed.
+ */
 int Binlog_archive::stop_waiting_for_mysql_binlog_update(my_off_t log_pos) {
   // Check whether consensus role is leader
   if (consensus_leader_is_changed()) {
@@ -1504,6 +2027,12 @@ int Binlog_archive::stop_waiting_for_mysql_binlog_update(my_off_t log_pos) {
   return 1;
 }
 
+/**
+ * @brief Wait for new mysql binlog events.
+ *
+ * @param log_pos mysql binlog position
+ * @return 0 if success, -1 if failed.
+ */
 int Binlog_archive::wait_new_mysql_binlog_events(my_off_t log_pos) {
   DBUG_TRACE;
   DBUG_PRINT("info", ("wait_new_mysql_binlog_events"));
@@ -1526,18 +2055,26 @@ int Binlog_archive::wait_new_mysql_binlog_events(my_off_t log_pos) {
                     mysql_bin_log.get_binlog_end_pos_lock(), nullptr, nullptr);
   while ((ret = stop_waiting_for_mysql_binlog_update(log_pos)) == 1) {
     // wait opt_binlog_archive_period millisecond
-    if (m_slice_create_ts > 0)
-      mysql_bin_log.wait_for_update(timeout);
-    else
-      mysql_bin_log.wait_for_update();
+    mysql_bin_log.wait_for_update(timeout);
 
+    // Update index worker is failed, retry binlog archive run.
+    if (m_update_index_worker->update_index_is_failed()) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+             "check found update index failed");
+      ret = -1;
+      break;
+    }
+
+    // If the binlog slice has not been persisted for a long time, rotate the
+    // binlog slice. For purposes of binlog slice rotation, the binlog slice
+    // is considered to be persisted.
     ulonglong now = my_milli_time();
     if ((m_slice_create_ts > 0) &&
         ((ulonglong)(now - m_slice_create_ts) >= opt_binlog_archive_period)) {
       mysql_bin_log.unlock_binlog_end_pos();
       m_thd->EXIT_COND(nullptr);
 
-      rotate_binlog_slice(0, true);
+      if (rotate_binlog_slice(0, true) == 1) return -1;
 
       mysql_bin_log.lock_binlog_end_pos();
       m_thd->ENTER_COND(mysql_bin_log.get_log_cond(),
@@ -1551,6 +2088,23 @@ int Binlog_archive::wait_new_mysql_binlog_events(my_off_t log_pos) {
   return ret;
 }
 
+/**
+ * @brief Retrieves the end position of the binlog.
+ *
+ * This function reads the current position from the provided File_reader and
+ * attempts to determine the end position of the binlog. It also checks if the
+ * binlog is active or cold and adjusts the result accordingly.
+ *
+ * @param reader A reference to the File_reader object used to read the binlog.
+ * @return A pair containing the end position of the binlog and a status code.
+ *         The first element of the pair is the end position (my_off_t).
+ *         The second element of the pair is a status code (int):
+ *         - 1 if the binlog is active and the read position is at or beyond the
+ * end position.
+ *         - 0 if the binlog is active and the read position is before the end
+ * position.
+ *         - (0, 0) if the binlog is cold.
+ */
 std::pair<my_off_t, int> Binlog_archive::get_binlog_end_pos(
     File_reader &reader) {
   DBUG_TRACE;
@@ -1578,7 +2132,7 @@ std::pair<my_off_t, int> Binlog_archive::get_binlog_end_pos(
 }
 
 /**
- * @brief Create a new binlog slice local file.
+ * @brief Create a new binlog slice local cache.
  *
  * @param new_binlog switch next binlog
  * @param log_file mysql binlog
@@ -1597,6 +2151,8 @@ int Binlog_archive::new_binlog_slice(bool new_binlog, const char *log_file,
   // Generate the next archive binlog file name.
   // Generate the first binlog slice.
   if (new_binlog) {
+    m_current_file_seq++;
+    m_current_slice_seq = -1;
     m_binlog_archive_last_index_number++;
     m_mysql_binlog_first_file = false;
     m_binlog_previouse_consensus_index = previous_consensus_index;
@@ -1619,6 +2175,8 @@ int Binlog_archive::new_binlog_slice(bool new_binlog, const char *log_file,
   // rotate new archive binlog slice.
   m_slice_cache.clear();
   m_slice_create_ts = my_milli_time();
+  if (m_mysql_binlog_first_file) m_current_file_seq = 0;
+  m_current_slice_seq++;
   LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
 
   return error;
@@ -1643,6 +2201,14 @@ int Binlog_archive::rotate_binlog_slice(my_off_t log_pos, bool need_lock) {
   DBUG_PRINT("debug", ("Binlog archive request rotate binlog slice: expected "
                        "mysql position=%lld",
                        log_pos));
+
+  // Check if update index worker is failed, retry binlog archive run.
+  if (m_update_index_worker->update_index_is_failed()) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+           "check found update index failed");
+    error = 1;
+    goto end;
+  }
 
   // msyql binlog log_pos already archived.
   if (log_pos > 0 && m_mysql_binlog_last_event_end_pos >= log_pos) {
@@ -1681,8 +2247,7 @@ int Binlog_archive::rotate_binlog_slice(my_off_t log_pos, bool need_lock) {
     err_msg.append(m_binlog_archive_file_name);
     err_msg.append(":");
     err_msg.append(std::to_string(m_binlog_archive_write_last_event_end_pos));
-    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
-    error = 1;
+    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
     goto end;
   }
 
@@ -1705,17 +2270,11 @@ int Binlog_archive::rotate_binlog_slice(my_off_t log_pos, bool need_lock) {
     err_msg.append(" end consensus index=");
     err_msg.append(std::to_string(m_mysql_end_consensus_index));
 
-    // No longer check whether the current node's role has changed; even if a
-    // change occurs, the slice will still be persisted to S3. Since the current
-    // version of the binlog is being used, it won't affect other term versions.
-    // However, this might result in some unnecessary data.
-    /*
     // Check whether consensus role is leader
     if (consensus_leader_is_changed()) {
       error = 1;
       goto end;
-     }
-    */
+    }
     // Upload the local archived binlog slice to the object store.
     std::string archived_binlog_keyid{};
     std::string binlog_slice_name{};
@@ -1725,46 +2284,39 @@ int Binlog_archive::rotate_binlog_slice(my_off_t log_pos, bool need_lock) {
         m_binlog_archive_write_last_event_end_pos, m_consensus_term);
     archived_binlog_keyid.append(binlog_slice_name);
 
-    objstore::Status ss = binlog_objstore->put_object(
-        std::string_view(opt_objstore_bucket), archived_binlog_keyid,
-        std::string_view(m_slice_cache), true);
-    err_msg.append(" put slice object ");
-    err_msg.append(archived_binlog_keyid);
-    err_msg.append(" slice last event type=");
-    err_msg.append(m_binlog_last_event_type_str);
-    if (!ss.is_succ()) {
-      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_PUT_OBJECT_FROM_BINLOG_SLICE_FILE,
-             archived_binlog_keyid.c_str(), "",
-             m_slice_bytes_written, std::string(ss.error_message()).c_str());
-      error = 1;
-      goto end;
-    }
-    LogErr(INFORMATION_LEVEL,
-           ER_BINLOG_ARCHIVE_PUT_OBJECT_FROM_BINLOG_SLICE_FILE,
-           archived_binlog_keyid.c_str(), "",
-           m_slice_bytes_written, "");
+    // write slice_cache to m_expected_slice_queue
+    Binlog_expected_slice slice(archived_binlog_keyid.c_str(), m_slice_cache,
+                                m_slice_bytes_written, m_current_file_seq,
+                                m_current_slice_seq);
+    SLICE_INFO slice_info;
+    strmake(slice_info.log_file_name, m_binlog_archive_file_name,
+            sizeof(slice_info.log_file_name) - 1);
+    strmake(slice_info.log_slice_name, binlog_slice_name.c_str(),
+            sizeof(slice_info.log_slice_name) - 1);
+    strmake(slice_info.mysql_log_name, m_mysql_binlog_file_name,
+            sizeof(slice_info.mysql_log_name) - 1);
+    slice_info.log_slice_end_consensus_index = m_mysql_end_consensus_index;
+    slice_info.log_slice_previous_consensus_index =
+        m_binlog_previouse_consensus_index;
+    slice_info.log_slice_consensus_term = m_consensus_term;
+    slice_info.log_slice_end_pos = m_binlog_archive_write_last_event_end_pos;
+    slice_info.mysql_end_pos = m_mysql_binlog_write_last_event_end_pos;
 
-    // Append slice to the persistent binlog.index.
-    // When we are done with the file, we need to record it in the index.
-    // record binlog real file name to the index file.
-    mysql_mutex_lock(&m_index_lock);
-    std::string binlog_entry;
-    binlog_entry.assign(binlog_slice_name);
-    binlog_entry.append("|");
-    binlog_entry.append(std::to_string(m_mysql_end_consensus_index));
-    binlog_entry.append("|");
-    binlog_entry.append(std::to_string(m_binlog_previouse_consensus_index));
-    err_msg.append(" log index entry=");
-    err_msg.append(binlog_entry);
-    if (add_log_to_index(reinterpret_cast<const uchar *>(binlog_entry.c_str()),
-                         binlog_entry.length())) {
-      err_msg.append(" failed");
-      LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+    // Before adding the slice to the expected slice queue, release the rotate
+    // lock.
+    if (need_lock) {
+      mysql_mutex_unlock(&m_rotate_lock);
+    }
+    if (!add_slice(slice, slice_info)) {
       error = 1;
-      mysql_mutex_unlock(&m_index_lock);
+      if (need_lock) {
+        mysql_mutex_lock(&m_rotate_lock);
+      }
       goto end;
     }
-    mysql_mutex_unlock(&m_index_lock);
+    if (need_lock) {
+      mysql_mutex_lock(&m_rotate_lock);
+    }
     m_slice_end_consensus_index = m_mysql_end_consensus_index;
     m_binlog_archive_last_event_end_pos =
         m_binlog_archive_write_last_event_end_pos;
@@ -1778,12 +2330,254 @@ int Binlog_archive::rotate_binlog_slice(my_off_t log_pos, bool need_lock) {
   assert(log_pos == 0 || m_mysql_binlog_last_event_end_pos >= log_pos);
 
 end:
-  // Signal update after every slice.
-  signal_archive();
   if (need_lock) {
     mysql_mutex_unlock(&m_rotate_lock);
   }
   return error;
+}
+
+/**
+ * @brief Add a slice to the expected slice queue.
+ *
+ * @param slice
+ */
+bool Binlog_archive::add_slice(Binlog_expected_slice &slice,
+                               SLICE_INFO &log_info) {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("add_slice"));
+  std::string err_msg;
+  err_msg.assign("add slice to expected slice queue ");
+  err_msg.append("file_seq=");
+  err_msg.append(std::to_string(slice.m_file_seq));
+  err_msg.append(" slice_seq=");
+  err_msg.append(std::to_string(slice.m_slice_seq));
+  err_msg.append(" log_slice_keyid=");
+  err_msg.append(slice.m_slice_keyid);
+  err_msg.append(" slice_size=");
+  err_msg.append(std::to_string(slice.m_slice_bytes_written));
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+
+  DBUG_EXECUTE_IF("fault_injection_add_slice_queue", {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+           "fault_injection_add_slice_queue");
+    return false;
+  });
+
+  mysql_mutex_lock(&m_slice_mutex);
+  m_slice_queue_and_map_initted = true;
+  m_thd->ENTER_COND(&m_queue_cond, &m_slice_mutex, nullptr, nullptr);
+  while (m_expected_slice_queue.full() && !m_thd->killed) {
+    // Wait for signal from the binlog archive worker thread that the slice
+    // is persisted and dequeued from the expected slice queue.
+    // Or binlog archive thread is killed.
+    mysql_cond_wait(&m_queue_cond, &m_slice_mutex);
+  }
+  m_expected_slice_queue.en_queue(&slice);
+  mysql_mutex_unlock(&m_slice_mutex);
+  m_thd->EXIT_COND(nullptr);
+  if (m_thd->killed) {
+    return false;
+  }
+  m_slice_status_map[slice.m_file_seq][slice.m_slice_seq] =
+      Slice_status(slice.m_file_seq, slice.m_slice_seq, log_info);
+  // Signal the binlog archive worker thread that wait, because the slice queue
+  // is empty.
+  mysql_cond_signal(&m_queue_cond);
+  return true;
+}
+
+/**
+ * @brief Notify that a slice has been persisted.
+ *
+ * @param slice
+ */
+void Binlog_archive::notify_slice_persisted(const Binlog_expected_slice &slice,
+                                            bool is_slice_persisted) {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("notify_slice_persisted"));
+  std::string err_msg;
+  err_msg.assign("notify slice persisted ");
+  err_msg.append("file_seq=");
+  err_msg.append(std::to_string(slice.m_file_seq));
+  err_msg.append(" slice_seq=");
+  err_msg.append(std::to_string(slice.m_slice_seq));
+  err_msg.append(" log_slice_keyid=");
+  err_msg.append(slice.m_slice_keyid);
+  err_msg.append(is_slice_persisted ? " success" : " failed");
+  LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+
+  mysql_mutex_lock(&m_slice_mutex);
+  // If the slice queue and map have not been initialized or reinitialized,
+  // there is no need to update the slice status map. Skip the update.
+  // This is to prevent the slice status map from being updated after the
+  // binlog archive reinitializes the slice queue and map.
+  if (!m_slice_queue_and_map_initted) {
+    mysql_mutex_unlock(&m_slice_mutex);
+    err_msg.append(" skiped when slice queue and map not initted");
+    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+    return;
+  }
+  auto &slice_status = m_slice_status_map[slice.m_file_seq][slice.m_slice_seq];
+  slice_status.persisted =
+      is_slice_persisted ? SLICE_PERSISTED : SLICE_PERSISTED_FAILED;
+  mysql_mutex_unlock(&m_slice_mutex);
+  mysql_cond_signal(&m_map_cond);
+}
+
+/**
+ * @brief Update the binlog index file with the persisted slices.
+ *
+ * @param need_slice_lock Whether to acquire the slice mutex lock.
+ * @return true if the index file is successfully updated; otherwise, false.
+ */
+bool Binlog_archive::update_index_file(bool need_slice_lock) {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("update_index_file"));
+  std::vector<Slice_status> to_process;
+  std::string err_msg;
+
+  DBUG_EXECUTE_IF("fault_injection_binlog_archive_update_index_file", {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_UPDATE_INDEX_WORKER_LOG,
+           "fault_injection_binlog_archive_update_index_file");
+    return false;
+  });
+
+  if (need_slice_lock) mysql_mutex_lock(&m_slice_mutex);
+  // Process from map beginning
+  auto file_it = m_slice_status_map.begin();
+  while (file_it != m_slice_status_map.end()) {
+    auto &slice_map = file_it->second;
+
+    // Process slices from beginning of current file
+    auto slice_it = slice_map.begin();
+    while (slice_it != slice_map.end()) {
+      if (slice_it->second.persisted == SLICE_PERSISTED_FAILED) {
+        if (need_slice_lock) mysql_mutex_unlock(&m_slice_mutex);
+        err_msg.assign(" binlog slice persisted failed, slice=");
+        err_msg.append(slice_it->second.archived_info.log_slice_name);
+        LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+        return false;
+      }
+      if (slice_it->second.persisted == SLICE_NOT_PERSISTED) {
+        // Stop at first non-persisted slice
+        break;
+      }
+      // Add to processing batch
+      to_process.push_back(slice_it->second);
+      slice_it = slice_map.erase(slice_it);
+    }
+
+    if (slice_map.empty()) {
+      // Remove empty file map
+      file_it = m_slice_status_map.erase(file_it);
+    } else {
+      // Stop at first file with remaining slices
+      break;
+    }
+  }
+  if (need_slice_lock) mysql_mutex_unlock(&m_slice_mutex);
+
+  // Batch update index with all collected slices.
+  if (!to_process.empty()) {
+    err_msg.assign(" batch put log index entry count=");
+    err_msg.append(std::to_string(to_process.size()));
+    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+
+    mysql_mutex_lock(&m_index_lock);
+    if (open_index_file()) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to open_index_file");
+      mysql_mutex_unlock(&m_index_lock);
+      return false;
+    }
+    if (open_crash_safe_index_file()) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+             "failed to open_crash_safe_index_file");
+      mysql_mutex_unlock(&m_index_lock);
+      return false;
+    }
+
+    if (copy_file(&m_index_file, &m_crash_safe_index_file, 0)) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to copy_file");
+      mysql_mutex_unlock(&m_index_lock);
+      return false;
+    }
+
+    // Batch update index with all collected slices
+    for (const auto &slice : to_process) {
+      std::string binlog_entry;
+      binlog_entry.assign(slice.archived_info.log_slice_name);
+      binlog_entry.append("|");
+      binlog_entry.append(
+          std::to_string(slice.archived_info.log_slice_end_consensus_index));
+      binlog_entry.append("|");
+      binlog_entry.append(std::to_string(
+          slice.archived_info.log_slice_previous_consensus_index));
+
+      if (my_b_write(&m_crash_safe_index_file,
+                     reinterpret_cast<const uchar *>(binlog_entry.c_str()),
+                     binlog_entry.length()) ||
+          my_b_write(&m_crash_safe_index_file,
+                     pointer_cast<const uchar *>("\n"), 1)) {
+        LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to my_b_write");
+        mysql_mutex_unlock(&m_index_lock);
+        return false;
+      }
+    }
+    if (flush_io_cache(&m_crash_safe_index_file) ||
+        mysql_file_sync(m_crash_safe_index_file.file, MYF(MY_WME))) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to mysql_file_sync");
+      mysql_mutex_unlock(&m_index_lock);
+      return false;
+    }
+
+    if (close_crash_safe_index_file()) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+             "failed to close_crash_safe_index_file");
+      mysql_mutex_unlock(&m_index_lock);
+      return false;
+    }
+
+    // If failed, recover the index file from object store
+    // when restart the binlog archiving from run()->while{}.
+    if (move_crash_safe_index_file_to_index_file()) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+             "failed to move_crash_safe_index_file_to_index_file");
+      mysql_mutex_unlock(&m_index_lock);
+      return false;
+    }
+    mysql_mutex_unlock(&m_index_lock);
+
+    mysql_mutex_lock(&m_rotate_lock);
+    Slice_status &last_slice = static_cast<Slice_status &>(to_process.back());
+    strmake(m_persisted_binlog_file_name,
+            last_slice.archived_info.log_file_name,
+            sizeof(m_persisted_binlog_file_name) - 1);
+    strmake(m_persisted_mysql_binlog_file_name,
+            last_slice.archived_info.mysql_log_name,
+            sizeof(m_persisted_mysql_binlog_file_name) - 1);
+    m_persisted_binlog_last_event_end_pos =
+        last_slice.archived_info.log_slice_end_pos;
+    m_persisted_slice_end_consensus_index =
+        last_slice.archived_info.log_slice_end_consensus_index;
+    m_persisted_binlog_previouse_consensus_index =
+        last_slice.archived_info.log_slice_previous_consensus_index;
+    m_persisted_mysql_binlog_last_event_end_pos =
+        last_slice.archived_info.mysql_end_pos;
+    mysql_mutex_unlock(&m_rotate_lock);
+    err_msg.assign("update index file success ");
+    err_msg.append("last persisted slice=");
+    err_msg.append(last_slice.archived_info.log_slice_name);
+    err_msg.append(" end pos=");
+    err_msg.append(std::to_string(m_persisted_binlog_last_event_end_pos));
+    err_msg.append(" end consensus index=");
+    err_msg.append(std::to_string(m_persisted_slice_end_consensus_index));
+    err_msg.append(" mysql binlog=");
+    err_msg.append(m_persisted_mysql_binlog_file_name);
+    err_msg.append(" mysql end pos=");
+    err_msg.append(std::to_string(m_persisted_mysql_binlog_last_event_end_pos));
+    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+  }
+  return true;
 }
 
 /**
@@ -1921,13 +2715,6 @@ int Binlog_archive::move_crash_safe_index_file_to_index_file() {
   objstore::Status ss{};
   std::string index_keyid{};
 
-  // Check whether consensus role is leader
-  if (consensus_leader_is_changed()) {
-    mysql_file_delete(key_file_binlog_index, m_crash_safe_index_local_file_name,
-                      MYF(0));
-    error = 1;
-    goto err;
-  }
   index_keyid.assign(m_binlog_archive_dir);
   index_keyid.append(m_index_file_name);
   // 1. persist local crash index file to s3, retry 5 times.
@@ -2065,19 +2852,19 @@ int Binlog_archive::add_log_to_index(const uchar *log_name,
   DBUG_EXECUTE_IF("fail_to_write_binlog_slice_to_persistent_binlog_index",
                   { return LOG_INFO_IO; });
 
-  if (!my_b_inited(&m_index_file)) {
-    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "binlog index file not opened.");
-    return LOG_INFO_IO;
+  if (open_index_file()) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to open_index_file");
+    goto err;
   }
 
   if (open_crash_safe_index_file()) {
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "failed to open_crash_safe_index_file.");
+           "failed to open_crash_safe_index_file");
     goto err;
   }
 
   if (copy_file(&m_index_file, &m_crash_safe_index_file, 0)) {
-    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to copy_file.");
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to copy_file");
     goto err;
   }
 
@@ -2086,13 +2873,13 @@ int Binlog_archive::add_log_to_index(const uchar *log_name,
                  1) ||
       flush_io_cache(&m_crash_safe_index_file) ||
       mysql_file_sync(m_crash_safe_index_file.file, MYF(MY_WME))) {
-    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to my_b_write.");
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "failed to my_b_write");
     goto err;
   }
 
   if (close_crash_safe_index_file()) {
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "failed to close_crash_safe_index_file.");
+           "failed to close_crash_safe_index_file");
     goto err;
   }
 
@@ -2100,7 +2887,7 @@ int Binlog_archive::add_log_to_index(const uchar *log_name,
   // when restart the binlog archiving from run()->while{}.
   if (move_crash_safe_index_file_to_index_file()) {
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "failed to move_crash_safe_index_file_to_index_file.");
+           "failed to move_crash_safe_index_file_to_index_file");
     goto err;
   }
 
@@ -2360,7 +3147,8 @@ int Binlog_archive::find_log_pos_common(IO_CACHE *index_file,
     std::string found_end_consensus_index = left_string.substr(0, idx);
     linfo->slice_end_consensus_index = std::stoull(found_end_consensus_index);
     std::string found_previous_consensus_index = left_string.substr(idx + 1);
-    linfo->log_previous_consensus_index = std::stoull(found_previous_consensus_index);
+    linfo->log_previous_consensus_index =
+        std::stoull(found_previous_consensus_index);
 
     strmake(linfo->log_slice_name, found_log_slice_name.c_str(),
             sizeof(linfo->log_slice_name) - 1);
@@ -2407,7 +3195,7 @@ int Binlog_archive::find_log_pos_by_name(LOG_ARCHIVED_INFO *linfo,
 }
 
 /**
-  Find the position in the log-index-file for the given log name.
+ * @brief Find the position in the log-index-file for the given log name.
 
   @param[out] linfo The filename will be stored here, along with the
   byte offset of the next filename in the index file.
@@ -2479,7 +3267,8 @@ int Binlog_archive::find_next_log_common(IO_CACHE *index_file,
     std::string found_end_consensus_index = left_string.substr(0, idx);
     linfo->slice_end_consensus_index = std::stoull(found_end_consensus_index);
     std::string found_previous_consensus_index = left_string.substr(idx + 1);
-    linfo->log_previous_consensus_index = std::stoull(found_previous_consensus_index);
+    linfo->log_previous_consensus_index =
+        std::stoull(found_previous_consensus_index);
 
     strmake(linfo->log_slice_name, found_log_slice_name.c_str(),
             sizeof(linfo->log_slice_name) - 1);
@@ -2513,30 +3302,62 @@ int Binlog_archive::find_next_log_slice(LOG_ARCHIVED_INFO *linfo) {
   return find_next_log_common(&m_index_file, linfo, true);
 }
 
+/**
+ * @brief Get binlog archive info.
+ *
+ * @param persisting_consensus_index
+ * @param consensus_term
+ * @param persisting_mysql_binlog
+ * @param persisting_mysql_binlog_pos
+ * @param persisting_mysql_binlog_write_pos
+ * @param persisting_binlog
+ * @param persisting_binlog_pos
+ * @param persisting_binlog_write_pos
+ * @param persisted_binlog
+ * @param persisted_binlog_pos
+ * @param persisted_consensus_index
+ * @param persisted_mysql_binlog
+ * @param persisted_mysql_binlog_pos
+ * @return int
+ */
 int Binlog_archive::show_binlog_archive_task_info(
-    uint64_t &consensus_index, uint64_t &consensus_term,
-    std::string &mysql_binlog, my_off_t &mysql_binlog_pos,
-    my_off_t &mysql_binlog_write_pos, std ::string &binlog,
-    my_off_t &binlog_pos, my_off_t &binlog_write_pos) {
+    uint64_t &persisting_consensus_index, uint64_t &consensus_term,
+    std::string &persisting_mysql_binlog, my_off_t &persisting_mysql_binlog_pos,
+    my_off_t &persisting_mysql_binlog_write_pos, std::string &persisting_binlog,
+    my_off_t &persisting_binlog_pos, my_off_t &persisting_binlog_write_pos,
+    std::string &persisted_binlog, my_off_t &persisted_binlog_pos,
+    uint64_t &persisted_consensus_index, std::string &persisted_mysql_binlog,
+    my_off_t &persisted_mysql_binlog_pos) {
   mysql_mutex_lock(&m_rotate_lock);
-  mysql_binlog_pos = m_mysql_binlog_last_event_end_pos;
-  mysql_binlog_write_pos = m_mysql_binlog_write_last_event_end_pos;
-  mysql_binlog.assign(m_mysql_binlog_file_name);
-  binlog.assign(m_binlog_archive_file_name);
-  binlog_pos = m_binlog_archive_last_event_end_pos;
-  binlog_write_pos = m_binlog_archive_write_last_event_end_pos;
+  persisting_mysql_binlog_pos = m_mysql_binlog_last_event_end_pos;
+  persisting_mysql_binlog_write_pos = m_mysql_binlog_write_last_event_end_pos;
+  persisting_mysql_binlog.assign(m_mysql_binlog_file_name);
+  persisting_binlog.assign(m_binlog_archive_file_name);
+  persisting_binlog_pos = m_binlog_archive_last_event_end_pos;
+  persisting_binlog_write_pos = m_binlog_archive_write_last_event_end_pos;
   consensus_term = m_consensus_term;
-  consensus_index = m_slice_end_consensus_index;
+  persisting_consensus_index = m_slice_end_consensus_index;
+
+  persisted_binlog.assign(m_persisted_binlog_file_name);
+  persisted_binlog_pos = m_persisted_binlog_last_event_end_pos;
+  persisted_consensus_index = m_persisted_slice_end_consensus_index;
+  persisted_mysql_binlog.assign(m_persisted_mysql_binlog_file_name);
+  persisted_mysql_binlog_pos = m_persisted_mysql_binlog_last_event_end_pos;
+
   mysql_mutex_unlock(&m_rotate_lock);
   return 0;
 }
 
+/**
+ * @brief Get last persisted mysql binlog file and position.
+ *
+ */
 int Binlog_archive::get_mysql_current_archive_binlog(LOG_INFO *linfo,
                                                      bool need_lock /*true*/) {
   if (need_lock) mysql_mutex_lock(&m_rotate_lock);
-  strmake(linfo->log_file_name, m_mysql_binlog_file_name,
+  strmake(linfo->log_file_name, m_persisted_mysql_binlog_file_name,
           sizeof(linfo->log_file_name) - 1);
-  linfo->pos = m_mysql_binlog_write_last_event_end_pos;
+  linfo->pos = m_persisted_mysql_binlog_last_event_end_pos;
   if (need_lock) mysql_mutex_unlock(&m_rotate_lock);
   return 1;
 }
@@ -2568,44 +3389,73 @@ int Binlog_archive::binlog_is_archived(const char *log_file_name_arg,
   err_msg.append(std::to_string(log_pos));
   err_msg.append(" consensus index=");
   err_msg.append(std::to_string(consensus_index));
-  // 1. If the binlog file is the current mysql binlog file.
-  // rotate binlog slice by mysql log_pos.
-  if (0 == compare_log_name(m_mysql_binlog_file_name, log_file_name_arg) &&
-      (log_pos > 0 && m_mysql_binlog_write_last_event_end_pos < log_pos)) {
-    err_msg.append(" has not yet been readed by the binlog archive thread");
+
+  // Not acquired m_rotate_lock here.
+  // Check if the requested consensus index is beyond what has been read by the
+  // binlog archive thread
+  if (consensus_index > m_persisted_slice_end_consensus_index) {
+    err_msg.append(" has not yet been persisted");
     LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
-    return 1;        
+    return 1;  // Return 1 to indicate need to wait for archive
   }
 
+  // Not acquired m_rotate_lock here.
+  // Check if the log file is the current persisted mysql binlog file and if the
+  // log position has not yet been persisted.
+  if (0 == compare_log_name(m_persisted_mysql_binlog_file_name,
+                            log_file_name_arg) &&
+      (log_pos > 0 && m_persisted_mysql_binlog_last_event_end_pos < log_pos)) {
+    err_msg.append(" persisted mysql binlog end pos=");
+    err_msg.append(std::to_string(m_persisted_mysql_binlog_last_event_end_pos));
+    err_msg.append(", continue to wait binlog persistence");
+    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+    return 1;
+  }
+
+  // Acquire lock when accessing persisted file info
   mysql_mutex_lock(&m_rotate_lock);
-  if (m_mysql_binlog_file_name[0] != '\0' &&
-      0 == compare_log_name(m_mysql_binlog_file_name, log_file_name_arg)) {
-    if (rotate_binlog_slice(log_pos, false)) {
-      ret = 1;
+  // Check if this log file matches the last persisted mysql binlog file
+  if (m_persisted_mysql_binlog_file_name[0] != '\0' &&
+      0 == compare_log_name(m_persisted_mysql_binlog_file_name,
+                            log_file_name_arg)) {
+    // Check if requested position is beyond what has been persisted
+    if ((log_pos > 0 &&
+         log_pos > m_persisted_mysql_binlog_last_event_end_pos)) {
+      err_msg.append(" persisted mysql binlog end pos=");
+      err_msg.append(
+          std::to_string(m_persisted_mysql_binlog_last_event_end_pos));
+      err_msg.append(", continue to wait binlog persistence");
+      LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
+      ret = 1;  // Return 1 to indicate need to wait for persistence
     } else {
-      err_msg.append(" has being archived");
+      err_msg.append(" has been persisted as current persisted binlog");
       LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
-      // Update mysql binlog filename to the archived binlog filename
-      strmake(persistent_log_file_name, m_binlog_archive_file_name, FN_REFLEN);
-      ret = 0;
+      // Copy the persisted binlog filename to return to caller
+      strmake(persistent_log_file_name, m_persisted_binlog_file_name,
+              FN_REFLEN);
+      ret = 0;  // Return 0 to indicate binlog is persisted
     }
     mysql_mutex_unlock(&m_rotate_lock);
     return ret;
   }
-  // 2. If the log_file_name_arg to be archived is neither the current mysql
-  // file m_mysql_binlog_file_name nor is its consensus_index greater than the
-  // previous consensus index of the current file, it indicates that the binlog
-  // to be archived belongs to future binlogs.
-  if (consensus_index > m_slice_end_consensus_index) {
-    err_msg.append(" has not yet been readed by the binlog archive thread");
+
+  // Until here, the requetes log file is not the current persisted
+  // mysql binlog file.
+
+  // Check if the requested consensus index is beyond what has been read by the
+  // binlog archive thread
+  if (consensus_index > m_persisted_slice_end_consensus_index) {
+    err_msg.append(" persisted end consensus index=");
+    err_msg.append(std::to_string(m_persisted_slice_end_consensus_index));
+    err_msg.append(", continue to wait binlog persistence");
     LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
     mysql_mutex_unlock(&m_rotate_lock);
-    return 1;
+    return 1;  // Return 1 to indicate need to wait for archive
   }
   mysql_mutex_unlock(&m_rotate_lock);
 
   mysql_mutex_lock(&m_index_lock);
-  // 3. Check whether the binlog that needs to be archived has already been
+  // Check if the binlog that needs to be archived has already been
   // persisted by inspecting the `binlog.index`.
   if (open_index_file()) {
     err_msg.append(" binlog.index open failed");
@@ -2629,7 +3479,7 @@ int Binlog_archive::binlog_is_archived(const char *log_file_name_arg,
   if (consensus_index > 0) {  // consensus mode.
     int error = 0;
     if ((error = find_log_pos_by_name(&log_info, NullS))) {
-      // not found.
+      // Return 1 to indicate need to wait for archive
       ret = 1;
     } else {
       char pre_log[FN_REFLEN + 1] = {0};
@@ -2640,9 +3490,10 @@ int Binlog_archive::binlog_is_archived(const char *log_file_name_arg,
         err_msg.append(", persistent binlog has already been purged");
         LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
         mysql_mutex_unlock(&m_index_lock);
+        // Return 2 to indicate binlog has been purged
         return 2;
       }
-      // wait continue.
+      // Return 1 to indicate need to wait for archive
       ret = 1;
       do {
         // diff next persistent binlog previous consensus index.
@@ -2655,7 +3506,7 @@ int Binlog_archive::binlog_is_archived(const char *log_file_name_arg,
           err_msg.append(" found consensus_index=");
           err_msg.append(std::to_string(consensus_index));
           LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
-
+          // Return 0 to indicate binlog is persisted
           ret = 0;
           break;
         }
@@ -2679,13 +3530,15 @@ int Binlog_archive::binlog_is_archived(const char *log_file_name_arg,
  * @brief Signal other threads that the binlog archive is updated.
  *
  */
-void Binlog_archive::signal_archive() { mysql_cond_broadcast(&m_run_cond); }
+void Binlog_archive::signal_archive() {
+  mysql_cond_broadcast(&m_binlog_archive_run_cond);
+}
 
 /**
  * @brief Wait for the binlog file and position is archived.
  * @param log_file_name
  * @param log_pos
- * @note Must be called with m_run_lock held.
+ * @note Must be called with m_binlog_archive_run_lock held.
  * @return 0, archive success, stop wait.
  * @return 1, archive fail, continue wait.
  * @return 2, archive fail, stop wait.
@@ -2708,22 +3561,23 @@ int Binlog_archive::binlog_stop_waiting_for_archive(
 
 /**
  * @brief Wait for the binlog archive to finish.
- * Binlog_archive::archive_event() wakes up m_run_cond each time a binlog event
- * is persisted.
+ * Binlog_archive::archive_event() wakes up m_binlog_archive_run_cond when a
+ * binlog slice is persisted.
  * @return int
  */
 int Binlog_archive::wait_for_archive() {
   DBUG_TRACE;
-  mysql_mutex_assert_owner(&m_run_lock);
+  mysql_mutex_assert_owner(&m_binlog_archive_run_lock);
   struct timespec abstime;
   set_timespec(&abstime, 1);
-  return mysql_cond_timedwait(&m_run_cond, &m_run_lock, &abstime);
+  return mysql_cond_timedwait(&m_binlog_archive_run_cond,
+                              &m_binlog_archive_run_lock, &abstime);
 }
 
 /**
  * @brief For consistent snapshot arhcive,
  *        consistent snapshot thread wait for the binlog archive to finish.
- * */
+ */
 int binlog_archive_wait_for_archive(THD *thd, const char *log_file_name,
                                     char *persistent_log_file_name,
                                     my_off_t log_pos,
@@ -2734,14 +3588,15 @@ int binlog_archive_wait_for_archive(THD *thd, const char *log_file_name,
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, "Binlog archive is not enabled");
     return 0;
   }
-  mysql_mutex_lock(&m_run_lock);
+  mysql_mutex_lock(&m_binlog_archive_run_lock);
   if (!mysql_binlog_archive.is_thread_running()) {
-    mysql_mutex_unlock(&m_run_lock);
+    mysql_mutex_unlock(&m_binlog_archive_run_lock);
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
            "Binlog archive thread is not running");
     return 1;
   }
-  thd->ENTER_COND(&m_run_cond, &m_run_lock, nullptr, nullptr);
+  thd->ENTER_COND(&m_binlog_archive_run_cond, &m_binlog_archive_run_lock,
+                  nullptr, nullptr);
   // Check if waited binlog file is archived.
   while ((ret = mysql_binlog_archive.binlog_stop_waiting_for_archive(
               log_file_name, persistent_log_file_name, log_pos,
@@ -2754,7 +3609,7 @@ int binlog_archive_wait_for_archive(THD *thd, const char *log_file_name,
       break;
     }
   }
-  mysql_mutex_unlock(&m_run_lock);
+  mysql_mutex_unlock(&m_binlog_archive_run_lock);
   thd->EXIT_COND(nullptr);
   return ret;
 }
@@ -2858,13 +3713,25 @@ static bool recursive_create_dir(const std::string &dir,
   if (!my_stat(real_path.c_str(), &stat_area, MYF(0))) {
     if (my_mkdir(real_path.c_str(), 0777, MYF(0))) {
       LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-             "Failed to create binlog archive dir.");
+             "Failed to create binlog archive dir");
       return true;
     }
   }
   return recursive_create_dir(left, real_path);
 }
 
+/**
+ * @brief Automatically purges binary logs based on expiration settings.
+ *
+ * This function checks if the automatic purge option is enabled. If enabled, it
+ * calculates the lower time bound for purging logs and retrieves the list of
+ * binary log files. It then iterates through the list and identifies logs that
+ * need to be purged based on their last modified time. If such logs are found,
+ * it constructs the log name up to the second dot and calls the purge function
+ * to remove the logs.
+ *
+ * @return int Returns 0 on successful execution.
+ */
 int Binlog_archive::auto_purge_logs() {
   DBUG_TRACE;
   DBUG_PRINT("info", ("auto_purge_logs"));
@@ -2896,10 +3763,38 @@ int Binlog_archive::auto_purge_logs() {
 }
 
 /**
- * @brief Purge the pesistent binlog archive file.
- * @param to_log
- * @param decrease_log_space
- * @return std::tuple<bool, std::string>
+ * @brief Purge binary logs up to the specified log file.
+ *
+ * This function attempts to purge binary logs up to the specified log file
+ * name. It performs several checks and operations to ensure the consistency and
+ * integrity of the binary logs and their associated metadata.
+ *
+ * @param to_log The name of the log file up to which logs should be purged.
+ * @return A tuple containing an error code and an error message. The error code
+ * is 0 if the operation was successful, and non-zero otherwise.
+ *
+ * The function performs the following steps:
+ * 1. Logs the start of the purge operation.
+ * 2. Checks if consistent snapshot archiving is enabled and if the server is
+ * running in serverless mode.
+ *    - If the consistent snapshot thread is dead, the function returns with an
+ * error.
+ *    - Reads the snapshot index file and determines the oldest snapshot's
+ * binlog.
+ *    - Adjusts the purge log name if necessary to ensure it does not purge logs
+ * required by the oldest snapshot.
+ * 3. Locks the index file and opens it.
+ * 4. Finds the log position by name in the index file.
+ * 5. Opens the purge index file.
+ * 6. Registers the purge index entry and identifies any garbage binlog slices.
+ * 7. Synchronizes the purge index file.
+ * 8. Removes logs from the index file.
+ * 9. Purges each entry from the purge index file and deletes the corresponding
+ * files.
+ * 10. Cleans up garbage binlogs that do not exist in the index.
+ * 11. Purges old consensus term binlog-index files.
+ * 12. Closes the purge index file and unlocks the index file.
+ * 13. Returns the final error code and message.
  */
 std::tuple<int, std::string> Binlog_archive::purge_logs(const char *to_log) {
   DBUG_TRACE;
@@ -2936,7 +3831,7 @@ std::tuple<int, std::string> Binlog_archive::purge_logs(const char *to_log) {
         reinit_io_cache(index_file, READ_CACHE, (my_off_t)0, false, false)) {
       consistent_snapshot_archive->unlock_consistent_snapshot_index();
       error = 1;
-      err_msg.assign("snapshot.index is not opened.");
+      err_msg.assign("snapshot.index is not opened");
       LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
       return std::make_tuple(error, err_msg);
     }
@@ -3000,7 +3895,7 @@ std::tuple<int, std::string> Binlog_archive::purge_logs(const char *to_log) {
   mysql_mutex_lock(&m_index_lock);
   if (open_index_file()) {
     error = 1;
-    err_msg.assign("Binlog archive index file open failed.");
+    err_msg.assign("Binlog archive index file open failed");
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG, err_msg.c_str());
     goto err;
   }
@@ -3388,20 +4283,20 @@ int Binlog_archive::remove_logs_from_index(LOG_ARCHIVED_INFO *log_info) {
   // 1. update local crash index file.
   if (open_crash_safe_index_file()) {
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "failed to open_crash_safe_index_file in remove_logs_from_index.");
+           "failed to open_crash_safe_index_file in remove_logs_from_index");
     goto err;
   }
 
   if (copy_file(&m_index_file, &m_crash_safe_index_file,
                 log_info->index_file_start_offset)) {
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "failed to copy_file in remove_logs_from_index.");
+           "failed to copy_file in remove_logs_from_index");
     goto err;
   }
 
   if (close_crash_safe_index_file()) {
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "failed to close_crash_safe_index_file.");
+           "failed to close_crash_safe_index_file");
     goto err;
   }
 
@@ -3410,7 +4305,7 @@ int Binlog_archive::remove_logs_from_index(LOG_ARCHIVED_INFO *log_info) {
   // index from the object store again and reopen it when binlog archive retry.
   if (move_crash_safe_index_file_to_index_file()) {
     LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "failed to move_crash_safe_index_file_to_index_file.");
+           "failed to move_crash_safe_index_file_to_index_file");
     goto err;
   }
 
@@ -3420,6 +4315,17 @@ err:
   return LOG_INFO_IO;
 }
 
+/**
+ * @brief Show the persistent binlog files stored in the object store.
+ *
+ * This function lists the binlog files stored in the object store and appends
+ * their metadata to the provided vector of ObjectMeta objects.
+ *
+ * @param objects A reference to a vector where the metadata of the binlog files
+ *                will be stored.
+ * @return int Returns 0 on success, or 1 if an error occurs while listing the
+ *             binlog files.
+ */
 int Binlog_archive::show_binlog_persistent_files(
     std::vector<objstore::ObjectMeta> &objects) {
   DBUG_TRACE;
@@ -3583,6 +4489,11 @@ void Binlog_archive::calc_shrink_buffer_size(size_t current_size) {
   m_new_shrink_size = ALIGN_SIZE(new_size);
 }
 
+/**
+ * @brief  the lower time bound for automatic purging of binlog archives.
+ *
+ * @return The calculated expiration time as a time_t value.
+ */
 static time_t calculate_auto_purge_lower_time_bound() {
   if (DBUG_EVALUATE_IF("expire_all_persistent_binlogs", true, false)) {
     return time(nullptr);

--- a/sql/binlog_archive.h
+++ b/sql/binlog_archive.h
@@ -22,6 +22,7 @@
 #include "sql/binlog.h"
 #include "sql/binlog_reader.h"
 #include "sql/rpl_io_monitor.h"
+#include "sql/rpl_rli_pdb.h"
 #include "sql/sql_error.h"
 #include "sql_string.h"
 
@@ -63,6 +64,230 @@ struct LOG_ARCHIVED_INFO {
     memset(log_file_name, 0, FN_REFLEN);
     memset(log_slice_name, 0, FN_REFLEN);
   }
+
+  // Copy constructor
+  LOG_ARCHIVED_INFO(const LOG_ARCHIVED_INFO &other)
+      : slice_end_consensus_index(other.slice_end_consensus_index),
+        slice_consensus_term(other.slice_consensus_term),
+        log_previous_consensus_index(other.log_previous_consensus_index),
+        slice_end_pos(other.slice_end_pos),
+        index_file_offset(other.index_file_offset),
+        index_file_start_offset(other.index_file_start_offset),
+        pos(other.pos),
+        entry_index(other.entry_index) {
+    strmake(log_line, other.log_line, FN_REFLEN);
+    strmake(log_file_name, other.log_file_name, FN_REFLEN);
+    strmake(log_slice_name, other.log_slice_name, FN_REFLEN);
+  }
+
+  LOG_ARCHIVED_INFO &operator=(const LOG_ARCHIVED_INFO &other) {
+    if (this != &other) {
+      strmake(this->log_line, other.log_line, FN_REFLEN);
+      strmake(this->log_file_name, other.log_file_name, FN_REFLEN);
+      strmake(this->log_slice_name, other.log_slice_name, FN_REFLEN);
+      this->slice_end_consensus_index = other.slice_end_consensus_index;
+      this->slice_consensus_term = other.slice_consensus_term;
+      this->log_previous_consensus_index = other.log_previous_consensus_index;
+      this->slice_end_pos = other.slice_end_pos;
+      this->index_file_offset = other.index_file_offset;
+      this->index_file_start_offset = other.index_file_start_offset;
+      this->pos = other.pos;
+      this->entry_index = other.entry_index;
+    }
+    return *this;
+  }
+};
+
+struct SLICE_INFO {
+  char log_file_name[FN_REFLEN] = {0};
+  char log_slice_name[FN_REFLEN] = {0};
+  char mysql_log_name[FN_REFLEN] = {0};
+  uint64_t log_slice_end_consensus_index;
+  uint64_t log_slice_consensus_term;
+  uint64_t log_slice_previous_consensus_index;
+  my_off_t log_slice_end_pos;
+  my_off_t mysql_end_pos;
+  int entry_index;  // used in purge_logs(), calculated in find_log_pos().
+  SLICE_INFO()
+      : log_slice_end_consensus_index(0),
+        log_slice_consensus_term(0),
+        log_slice_previous_consensus_index(0),
+        log_slice_end_pos(0),
+        mysql_end_pos(0),
+        entry_index(0) {
+    memset(log_file_name, 0, FN_REFLEN);
+    memset(log_slice_name, 0, FN_REFLEN);
+    memset(mysql_log_name, 0, FN_REFLEN);
+  }
+
+  // Copy constructor
+  SLICE_INFO(const SLICE_INFO &other)
+      : log_slice_end_consensus_index(other.log_slice_end_consensus_index),
+        log_slice_consensus_term(other.log_slice_consensus_term),
+        log_slice_previous_consensus_index(
+            other.log_slice_previous_consensus_index),
+        log_slice_end_pos(other.log_slice_end_pos),
+        mysql_end_pos(other.mysql_end_pos),
+        entry_index(other.entry_index) {
+    strmake(log_file_name, other.log_file_name, FN_REFLEN);
+    strmake(log_slice_name, other.log_slice_name, FN_REFLEN);
+    strmake(mysql_log_name, other.mysql_log_name, FN_REFLEN);
+  }
+
+  SLICE_INFO &operator=(const SLICE_INFO &other) {
+    if (this != &other) {
+      strmake(log_file_name, other.log_file_name, FN_REFLEN);
+      strmake(log_slice_name, other.log_slice_name, FN_REFLEN);
+      strmake(mysql_log_name, other.mysql_log_name, FN_REFLEN);
+      log_slice_end_consensus_index = other.log_slice_end_consensus_index;
+      log_slice_consensus_term = other.log_slice_consensus_term;
+      log_slice_previous_consensus_index =
+          other.log_slice_previous_consensus_index;
+      log_slice_end_pos = other.log_slice_end_pos;
+      mysql_end_pos = other.mysql_end_pos;
+      entry_index = other.entry_index;
+    }
+    return *this;
+  }
+};
+
+/**
+ * @brief  Binlog expected slice structure.
+ *
+ */
+struct Binlog_expected_slice {
+  char m_slice_keyid[FN_REFLEN + 1];
+  std::string slice_data_cache;
+  uint32_t m_file_seq;
+  uint32_t m_slice_seq;
+  my_off_t m_slice_bytes_written;
+  // Default constructor
+  Binlog_expected_slice() = default;
+  // Constructor
+  Binlog_expected_slice(const char *keyid, const std::string &slice_data_cache,
+                        my_off_t slice_bytes, uint32_t file_seq,
+                        uint32_t slice_seq)
+      : m_file_seq(file_seq), m_slice_seq(slice_seq) {
+    strmake(this->m_slice_keyid, keyid, FN_REFLEN);
+    this->slice_data_cache = slice_data_cache;
+    this->m_slice_bytes_written = slice_bytes;
+  }
+
+  // Copy constructor
+  Binlog_expected_slice(const Binlog_expected_slice &other)
+      : slice_data_cache(other.slice_data_cache),
+        m_file_seq(other.m_file_seq),
+        m_slice_seq(other.m_slice_seq),
+        m_slice_bytes_written(other.m_slice_bytes_written) {
+    strmake(m_slice_keyid, other.m_slice_keyid, FN_REFLEN);
+  }
+
+  Binlog_expected_slice &operator=(const Binlog_expected_slice &other) {
+    if (this != &other) {
+      strmake(this->m_slice_keyid, other.m_slice_keyid, FN_REFLEN);
+      this->slice_data_cache = other.slice_data_cache;
+      this->m_file_seq = other.m_file_seq;
+      this->m_slice_seq = other.m_slice_seq;
+      this->m_slice_bytes_written = other.m_slice_bytes_written;
+    }
+    return *this;
+  }
+};
+
+enum Slice_status_enum {
+  SLICE_NOT_PERSISTED,
+  SLICE_PERSISTED,
+  SLICE_PERSISTED_FAILED
+};
+struct Slice_status {
+  Slice_status_enum persisted;
+  SLICE_INFO archived_info;
+  uint32_t file_seq;
+  uint32_t slice_seq;
+  Slice_status() : persisted(SLICE_NOT_PERSISTED), file_seq(0), slice_seq(0) {}
+
+  Slice_status(uint32_t f_seq, uint32_t s_seq, SLICE_INFO info)
+      : persisted(SLICE_NOT_PERSISTED),
+        archived_info(info),
+        file_seq(f_seq),
+        slice_seq(s_seq) {}
+};
+
+class Binlog_archive;
+
+/**
+ * @brief Binlog archive worker class.
+ *
+ */
+class Binlog_archive_worker {
+ public:
+  Binlog_archive_worker(Binlog_archive *archive, int worker_id);
+  ~Binlog_archive_worker();
+
+  bool start();
+  void stop();
+  static void *thread_launcher(void *arg) {
+    return static_cast<Binlog_archive_worker *>(arg)->worker_thread();
+  }
+  void *worker_thread();
+  void thread_set_created() { m_thd_state.set_created(); }
+  bool is_thread_alive_not_running() const {
+    return m_thd_state.is_alive_not_running();
+  }
+  bool is_thread_dead() const { return m_thd_state.is_thread_dead(); }
+  bool is_thread_alive() const { return m_thd_state.is_thread_alive(); }
+  bool is_thread_running() const { return m_thd_state.is_running(); }
+  int terminate_binlog_archive_worker_thread();
+
+ private:
+  Binlog_archive *m_archive;
+  my_thread_handle m_thread;
+  int m_worker_id;
+  Binlog_expected_slice m_current_slice;
+  THD *m_thd;
+  /* thread state */
+  thread_state m_thd_state;
+  mysql_mutex_t m_worker_run_lock;
+  mysql_cond_t m_worker_run_cond;
+};
+
+/**
+ * @brief Binlog archive update index worker class.
+ * 
+ */
+class Binlog_archive_update_index_worker {
+ public:
+  Binlog_archive_update_index_worker(Binlog_archive *archive);
+  ~Binlog_archive_update_index_worker();
+
+  bool start();
+  void stop();
+  static void *thread_launcher(void *arg) {
+    return static_cast<Binlog_archive_update_index_worker *>(arg)
+        ->worker_thread();
+  }
+  void *worker_thread();
+  void thread_set_created() { m_thd_state.set_created(); }
+  bool is_thread_alive_not_running() const {
+    return m_thd_state.is_alive_not_running();
+  }
+  bool is_thread_dead() const { return m_thd_state.is_thread_dead(); }
+  bool is_thread_alive() const { return m_thd_state.is_thread_alive(); }
+  bool is_thread_running() const { return m_thd_state.is_running(); }
+  int terminate_binlog_archive_update_index_worker();
+  bool update_index_is_failed() const { return atomic_update_index_failed.load(std::memory_order_acquire); }
+  void set_update_index_failed(bool failed) {
+    atomic_update_index_failed.store(failed, std::memory_order_release);
+  }
+ private:
+  Binlog_archive *m_archive;
+  my_thread_handle m_thread;
+  THD *m_thd;
+  /* thread state */
+  thread_state m_thd_state;
+  mysql_mutex_t m_worker_run_lock;
+  mysql_cond_t m_worker_run_cond;
+  std::atomic<bool> atomic_update_index_failed;
 };
 
 /**
@@ -114,8 +339,9 @@ class Binlog_archive {
   int archive_event(File_reader &reader, uchar *event_ptr, uint32 event_len,
                     const char *log_file, my_off_t log_pos);
   int binlog_stop_waiting_for_archive(const char *log_file_name,
-                               char *persistent_log_file_name, my_off_t log_pos,
-                               uint64_t consensus_index);
+                                      char *persistent_log_file_name,
+                                      my_off_t log_pos,
+                                      uint64_t consensus_index);
   int wait_for_archive();
   void signal_archive();
   int terminate_binlog_archive_thread();
@@ -135,24 +361,50 @@ class Binlog_archive {
     binlog_objstore = objstore;
   }
   inline objstore::ObjectStore *get_objstore() { return binlog_objstore; }
-  int show_binlog_archive_task_info(uint64_t &consensus_index,
-                                      uint64_t &consensus_term,
-                                      std::string &mysql_binlog,
-                                      my_off_t &mysql_binlog_pos,
-                                      my_off_t &mysql_binlog_write_pos,
-                                      std ::string &binlog,
-                                      my_off_t &binlog_pos,
-                                      my_off_t &binlog_write_pos);
+  int show_binlog_archive_task_info(
+      uint64_t &persisting_consensus_index, uint64_t &consensus_term,
+      std::string &persisting_mysql_binlog,
+      my_off_t &persisting_mysql_binlog_pos,
+      my_off_t &persisting_mysql_binlog_write_pos,
+      std::string &persisting_binlog, my_off_t &persisting_binlog_pos,
+      my_off_t &persisting_binlog_write_pos, std::string &persisted_binlog,
+      my_off_t &persisted_binlog_pos, uint64_t &persisted_consensus_index,
+      std::string &persisted_mysql_binlog,
+      my_off_t &persisted_mysql_binlog_pos);
 
-  int get_mysql_current_archive_binlog(LOG_INFO *linfo,
-                                   bool need_lock = true);
+  int get_mysql_current_archive_binlog(LOG_INFO *linfo, bool need_lock = true);
+
+  Binlog_archive_update_index_worker *m_update_index_worker;
+  Binlog_archive_worker **m_workers;
+  bool m_slice_queue_and_map_initted;
+  circular_buffer_queue<Binlog_expected_slice> m_expected_slice_queue;
+  mysql_mutex_t
+      m_slice_mutex;  // mutex for m_expected_slice_queue and m_slice_status_map
+  mysql_cond_t m_queue_cond;
+  // File and slice tracking
+  std::map<uint32_t, std::map<uint32_t, Slice_status>> m_slice_status_map;
+  mysql_cond_t m_map_cond;
+  int32_t m_current_file_seq{-1};
+  int32_t m_current_slice_seq{-1};
+  void notify_slice_persisted(const Binlog_expected_slice &slice,
+                              bool is_slice_persisted);
+  bool update_index_file(bool need_slice_lock);
  private:
   // the binlog archive THD handle.
   THD *m_thd;
   /* thread state */
   thread_state m_thd_state;
 
-  void set_thread_context();
+  bool add_slice(Binlog_expected_slice &slice, SLICE_INFO &log_info);
+  char m_persisted_binlog_file_name[FN_REFLEN + 1];
+  char m_persisted_mysql_binlog_file_name[FN_REFLEN + 1];
+  my_off_t m_persisted_mysql_binlog_last_event_end_pos;
+  my_off_t m_persisted_binlog_last_event_end_pos;  //  The last persisted binlog
+                                                   //  event position persisted
+                                                   //  to objstore.
+  uint64 m_persisted_slice_end_consensus_index;  // end consensus index of last
+                                                 // persisted binlogs.
+  uint64 m_persisted_binlog_previouse_consensus_index;
 
   /* current archive binlog file name, copy from mysql binlog file name
     e.g.
@@ -169,14 +421,14 @@ class Binlog_archive {
   Format_description_event m_description_event;
   objstore::ObjectStore *binlog_objstore;
   mysql_mutex_t m_rotate_lock;
-  bool m_consensus_is_leader;
   uint64_t m_consensus_term;
   my_off_t m_slice_bytes_written;
   my_off_t
       m_binlog_archive_last_event_end_pos;  //  The last binlog event position
                                             //  persisted to objstore.
-  my_off_t m_binlog_archive_write_last_event_end_pos;  // The last binlog event position
-                                               // writed to persistent cache.
+  my_off_t m_binlog_archive_write_last_event_end_pos;  // The last binlog event
+                                                       // position writed to
+                                                       // persistent cache.
   char m_mysql_binlog_start_file[FN_REFLEN + 1];
   my_off_t m_mysql_binlog_start_pos;  // mysql binlog archive start position.
   bool m_mysql_binlog_first_file;
@@ -192,9 +444,9 @@ class Binlog_archive {
   uint64
       m_mysql_binlog_previouse_consensus_index;  // the previous consensus index
                                                  // of current mysql binlog
-  uint64 m_binlog_previouse_consensus_index;     // the previous	
-                                                 // consensus index	
-                                                 // of previous	
+  uint64 m_binlog_previouse_consensus_index;     // the previous
+                                                 // consensus index
+                                                 // of previous
                                                  // mysql binlog
   uint64 m_binlog_archive_start_consensus_index;
   Log_event_type m_binlog_last_event_type;
@@ -205,8 +457,10 @@ class Binlog_archive {
   bool m_binlog_in_transaction;
   bool m_rotate_forbidden;
   ulonglong m_slice_create_ts;
-  uint64 m_slice_end_consensus_index; // end consensus index of persisted binlogs.
-  uint64 m_mysql_end_consensus_index; // end consensus index of readed mysql binlogs.
+  uint64
+      m_slice_end_consensus_index;  // end consensus index of persisted binlogs.
+  uint64 m_mysql_end_consensus_index;  // end consensus index of readed mysql
+                                       // binlogs.
   int new_binlog_slice(bool new_binlog, const char *log_file, my_off_t log_pos,
                        uint64_t previous_consensus_index);
   int archive_init();
@@ -223,8 +477,8 @@ class Binlog_archive {
                                       const my_off_t pos, const uint64_t term);
   int stop_waiting_for_mysql_binlog_update(my_off_t log_pos);
   int binlog_is_archived(const char *log_file_name_arg,
-                          char *persistent_log_file_name, my_off_t log_pos,
-                          uint64_t consensus_index);
+                         char *persistent_log_file_name, my_off_t log_pos,
+                         uint64_t consensus_index);
   int merge_slice_to_binlog_file(const char *log_name,
                                  const char *to_binlog_file);
   inline bool event_checksum_on() {
@@ -300,7 +554,7 @@ class Binlog_archive {
 extern int start_binlog_archive();
 extern void stop_binlog_archive();
 extern int binlog_archive_wait_for_archive(THD *thd, const char *log_file_name,
-                                          char *persistent_log_file_name,
-                                          my_off_t log_pos,
-                                          uint64_t consensus_index);
+                                           char *persistent_log_file_name,
+                                           my_off_t log_pos,
+                                           uint64_t consensus_index);
 #endif


### PR DESCRIPTION
Control the number of parallel workers for binlog persistence through ` binlog_archive_parallel_workers ` parameter. When purging MySQL binlogs, the binlog persistence checkpoint is checked, and any binlogs that have not been persisted are not allowed to be purged.