### PR TITLE
fix: binlog archive must wait for all workers to finish before rerun.

### DIFF
--- a/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_fault_injection.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_fault_injection.test
@@ -117,7 +117,7 @@ INSERT INTO t1 values(4,'abcd');
 --source include/grep_pattern.inc
 
 --let $grep_file=$error_log
---let $grep_pattern=binlog archive persistent abort
+--let $grep_pattern=persistent abort
 --let $grep_output=boolean
 --source include/grep_pattern.inc
 

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_fault_injection.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_fault_injection.test
@@ -159,7 +159,7 @@ INSERT INTO t1 values(4,'abcd');
 --source include/grep_pattern.inc
 
 --let $grep_file=$error_log
---let $grep_pattern=binlog archive persistent abort
+--let $grep_pattern=persistent abort
 --let $grep_output=boolean
 --source include/grep_pattern.inc
 

--- a/patches/mysql-server-8.0.35.patch
+++ b/patches/mysql-server-8.0.35.patch
@@ -7933,7 +7933,7 @@ index 61828fe0164..0c4a3aaa94e 100644
          if (mysql_bin_log.rotate_and_purge(thd, true)) *write_to_binlog = -1;
        }
 diff --git a/sql/sql_show.cc b/sql/sql_show.cc
-index 64c61f060db..b8b760aeaea 100644
+index 64c61f060db..2ca297bfae4 100644
 --- a/sql/sql_show.cc
 +++ b/sql/sql_show.cc
 @@ -72,6 +72,8 @@
@@ -7974,7 +7974,7 @@ index 64c61f060db..b8b760aeaea 100644
      table->field[TMP_TABLE_COLUMNS_COLUMN_KEY]->store(
          (const char *)pos, strlen((const char *)pos), cs);
  
-@@ -4957,6 +4958,501 @@ static int hton_fill_schema_table(THD *thd, Table_ref *tables, Item *cond) {
+@@ -4957,6 +4958,513 @@ static int hton_fill_schema_table(THD *thd, Table_ref *tables, Item *cond) {
    return 0;
  }
  
@@ -8088,10 +8088,22 @@ index 64c61f060db..b8b760aeaea 100644
 +    uint64_t log_previous_consensus_index = std::stoull(found_previous_consensus_index);
 +
 +    size_t first_dot = found_log_slice_name.find('.');
++    if (first_dot == std::string::npos) {
++      my_error(ER_IO_ERR_LOG_INDEX_READ, MYF(0));
++      goto err;
++    }
 +    size_t second_dot = found_log_slice_name.find('.', first_dot + 1);
++    if (second_dot == std::string::npos) {
++      my_error(ER_IO_ERR_LOG_INDEX_READ, MYF(0));
++      goto err;
++    }
 +    std::string log_name = found_log_slice_name.substr(0, second_dot);
 +    left_string = found_log_slice_name.substr(second_dot + 1);
 +    size_t third_dot = left_string.find('.');
++    if (third_dot == std::string::npos) {
++      my_error(ER_IO_ERR_LOG_INDEX_READ, MYF(0));
++      goto err;
++    }
 +    std::string term = left_string.substr(0, third_dot);
 +    std::string end_pos = left_string.substr(third_dot + 1);
 +    uint64_t slice_consensus_term = std::stoull(term);
@@ -8476,7 +8488,7 @@ index 64c61f060db..b8b760aeaea 100644
  ST_FIELD_INFO engines_fields_info[] = {
      {"ENGINE", 64, MYSQL_TYPE_STRING, 0, 0, "Engine", 0},
      {"SUPPORT", 8, MYSQL_TYPE_STRING, 0, 0, "Support", 0},
-@@ -5097,6 +5593,90 @@ ST_FIELD_INFO tmp_table_columns_fields_info[] = {
+@@ -5097,6 +5605,90 @@ ST_FIELD_INFO tmp_table_columns_fields_info[] = {
       MYSQL_TYPE_STRING, 0, 0, "Generation expression", 0},
      {nullptr, 0, MYSQL_TYPE_STRING, 0, 0, nullptr, 0}};
  
@@ -8567,7 +8579,7 @@ index 64c61f060db..b8b760aeaea 100644
  /** For creating fields of information_schema.OPTIMIZER_TRACE */
  extern ST_FIELD_INFO optimizer_trace_info[];
  
-@@ -5135,6 +5715,29 @@ ST_SCHEMA_TABLE schema_tables[] = {
+@@ -5135,6 +5727,29 @@ ST_SCHEMA_TABLE schema_tables[] = {
       make_tmp_table_columns_format, get_schema_tmp_table_columns_record, true},
      {"TMP_TABLE_KEYS", tmp_table_keys_fields_info, show_temporary_tables,
       make_old_format, get_schema_tmp_table_keys_record, true},

--- a/sql/binlog_archive_command.cc
+++ b/sql/binlog_archive_command.cc
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include "sql/binlog_archive_command.h"
 

--- a/sql/binlog_archive_command.h
+++ b/sql/binlog_archive_command.h
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #ifndef BINLOG_ARCHIVE_COMMAND_INCLUDED
 #define BINLOG_ARCHIVE_COMMAND_INCLUDED

--- a/sql/consistent_archive.cc
+++ b/sql/consistent_archive.cc
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include "sql/consistent_archive.h"
 

--- a/sql/consistent_archive.h
+++ b/sql/consistent_archive.h
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #ifndef CONSISTENT_ARCHIVE_INCLUDED
 #define CONSISTENT_ARCHIVE_INCLUDED

--- a/sql/consistent_recovery.cc
+++ b/sql/consistent_recovery.cc
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include "sql/consistent_recovery.h"
 

--- a/sql/consistent_recovery.h
+++ b/sql/consistent_recovery.h
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #ifndef CONSISTENT_RECOVERY_INCLUDED
 #define CONSISTENT_RECOVERY_INCLUDED

--- a/sql/consistent_snapshot_force_command.cc
+++ b/sql/consistent_snapshot_force_command.cc
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include "sql/consistent_snapshot_force_command.h"
 

--- a/sql/consistent_snapshot_force_command.h
+++ b/sql/consistent_snapshot_force_command.h
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #ifndef CONSISTENT_SNAPSHOT_FORCE_COMMAND_INCLUDED
 #define CONSISTENT_SNAPSHOT_FORCE_COMMAND_INCLUDED

--- a/sql/consistent_snapshot_purge_command.cc
+++ b/sql/consistent_snapshot_purge_command.cc
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include "sql/consistent_snapshot_purge_command.h"
 

--- a/sql/consistent_snapshot_purge_command.h
+++ b/sql/consistent_snapshot_purge_command.h
@@ -1,17 +1,26 @@
 /*
- * Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited 
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
 
- * http://www.apache.org/licenses/LICENSE-2.0
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #ifndef CONSISTENT_SNAPSHOT_PURGE_COMMAND_INCLUDED
 #define CONSISTENT_SNAPSHOT_PURGE_COMMAND_INCLUDED


### PR DESCRIPTION
1. The binlog archive thread must wait for all archive workers thread and update index worker thread to finish processing slices before it can resume execution.  First, wait for the archive worker to process all slices in the slice queue, then wait for the update index worker to finish processing all slices in the slice map.
2. Add more debug information.
3. Fix the license to GPL.