### PR TITLE
optimize: Optimize read performance by reducing block info deserialization

### DIFF
--- a/storage/smartengine/core/table/block_struct.h
+++ b/storage/smartengine/core/table/block_struct.h
@@ -48,8 +48,8 @@ class BlockHandle
 public:
   BlockHandle();
   BlockHandle(const BlockHandle &block_handle);
-  ~BlockHandle();
   BlockHandle &operator=(const BlockHandle &block_handle);
+  ~BlockHandle();
 
   void reset();
   bool is_valid() const;
@@ -81,64 +81,110 @@ class BlockInfo
 public:
   BlockInfo();
   BlockInfo(const BlockInfo &block_info);
-  ~BlockInfo();
   BlockInfo &operator=(const BlockInfo &block_info);
+  ~BlockInfo();
 
   void reset();
   bool is_valid() const;
-  inline void set_handle(BlockHandle handle) { handle_ = handle; }
-  inline const BlockHandle &get_handle() const { return handle_; }
-  inline BlockHandle &get_handle() { return handle_; }
+  inline void set_handle(BlockHandle handle) { critical_info_.set_handle(handle); }
+  inline const BlockHandle &get_handle() const { return critical_info_.get_handle(); }
+  inline BlockHandle &get_handle() { return critical_info_.get_handle(); }
+  inline void set_columnar_format() { critical_info_.set_columnar_format(); }
+  inline void set_row_format() { critical_info_.set_row_format(); }
+  inline bool is_columnar_format() const { return critical_info_.is_columnar_format(); }
+  inline void set_has_bloom_filter() { critical_info_.set_has_bloom_filter(); }
+  inline void unset_has_bloom_filter() { critical_info_.unset_has_bloom_filter(); }
+  inline bool has_bloom_filter() const { return critical_info_.has_bloom_filter(); }
+  inline void set_per_key_bits(int32_t per_key_bits) { critical_info_.set_per_key_bits(per_key_bits); }
+  inline int32_t get_per_key_bits() const { return critical_info_.get_per_key_bits(); }
+  inline void set_probe_num(int32_t probe_num) { critical_info_.set_probe_num(probe_num); }
+  inline int32_t get_probe_num() const { return critical_info_.get_probe_num(); }
+  inline void set_bloom_filter(const common::Slice &bloom_filter) { critical_info_.set_bloom_filter(bloom_filter); }
+  inline const common::Slice &get_bloom_filter() const { return critical_info_.get_bloom_filter(); }
+  inline const std::vector<ColumnUnitInfo> &get_unit_infos() const { return critical_info_.get_unit_infos(); }
+  inline std::vector<ColumnUnitInfo> &get_unit_infos() { return critical_info_.get_unit_infos(); }
   inline void set_first_key(const std::string &first_key) { first_key_ = first_key; }
   inline const std::string &get_first_key() const { return first_key_; }
-  inline void inc_row_count() { ++row_count_; }
-  inline int32_t get_row_count() const { return row_count_; }
+  inline void inc_row_count() { critical_info_.inc_row_count(); }
+  inline int32_t get_row_count() const { return critical_info_.get_row_count(); }
   inline void inc_delete_row_count() { ++delete_row_count_; }
   inline int32_t get_delete_row_count() const { return delete_row_count_; }
   inline void inc_single_delete_row_count() { ++single_delete_row_count_; }
   inline int32_t get_single_delete_row_count() const { return single_delete_row_count_; }
-  inline int64_t get_delete_percent() const { return ((delete_row_count_ + single_delete_row_count_) * 100) / row_count_; }
+  inline int64_t get_delete_percent() const { return ((delete_row_count_ + single_delete_row_count_) * 100) / critical_info_.get_row_count(); }
   inline void set_smallest_seq(common::SequenceNumber smallest_seq) { smallest_seq_ = smallest_seq; }
   inline common::SequenceNumber get_smallest_seq() const { return smallest_seq_; }
   inline void set_largest_seq(common::SequenceNumber largest_seq) { largest_seq_ = largest_seq; }
   inline common::SequenceNumber get_largest_seq() const { return largest_seq_; }
-  inline void set_columnar_format() { attr_ |= FLAG_COLUMNAR_FORMAT; }
-  inline void set_row_format() { attr_ &= (~FLAG_COLUMNAR_FORMAT); }
-  inline bool is_columnar_format() const { return 0 != (attr_ & FLAG_COLUMNAR_FORMAT); }
-  inline void set_has_bloom_filter() { attr_ |= FLAG_HAS_BLOOM_FILTER; }
-  inline void unset_has_bloom_filter() { attr_ &= (~FLAG_HAS_BLOOM_FILTER); }
-  inline bool has_bloom_filter() const { return 0 != (attr_ & FLAG_HAS_BLOOM_FILTER); }
-  inline void set_per_key_bits(int32_t per_key_bits) { per_key_bits_ = per_key_bits; }
-  inline int32_t get_per_key_bits() const { return  per_key_bits_; }
-  inline void set_probe_num(int32_t probe_num) { probe_num_ = probe_num; }
-  inline int32_t get_probe_num() const { return probe_num_; }
-  void set_bloom_filter(const common::Slice &bloom_filter);
-  inline const common::Slice &get_bloom_filter() const { return bloom_filter_; }
-  inline const std::vector<ColumnUnitInfo> &get_unit_infos() const { return unit_infos_; }
-  inline std::vector<ColumnUnitInfo> &get_unit_infos() { return unit_infos_; }
-  int64_t get_row_format_raw_size() const;
+  inline int64_t get_row_format_raw_size() const { return critical_info_.get_row_format_raw_size();}
+  int deserialize_critical_info(const char *buf, int64_t buf_len, int64_t &pos);
 
   static const int64_t BLOCK_INFO_VERSION = 1;
   DECLARE_SERIALIZATION()
   DECLARE_TO_STRING()
 
 private:
-  static const int8_t FLAG_COLUMNAR_FORMAT = 0x01;
-  static const int8_t FLAG_HAS_BLOOM_FILTER = 0x02;
+  class ReadCriticalInfo
+  {
+  public:
+    ReadCriticalInfo();
+    ReadCriticalInfo(const ReadCriticalInfo &other);
+    ReadCriticalInfo &operator=(const ReadCriticalInfo &other);
+    ~ReadCriticalInfo();
+
+    void reset();
+    bool is_valid() const;
+    inline void set_handle(BlockHandle handle) { handle_ = handle; }
+    inline const BlockHandle &get_handle() const { return handle_; }
+    inline BlockHandle &get_handle() { return handle_; }
+    inline void set_columnar_format() { attr_ |= FLAG_COLUMNAR_FORMAT; }
+    inline void set_row_format() { attr_ &= (~FLAG_COLUMNAR_FORMAT); }
+    inline bool is_columnar_format() const { return 0 != (attr_ & FLAG_COLUMNAR_FORMAT); }
+    inline void set_has_bloom_filter() { attr_ |= FLAG_HAS_BLOOM_FILTER; }
+    inline void unset_has_bloom_filter() { attr_ &= (~FLAG_HAS_BLOOM_FILTER); }
+    inline bool has_bloom_filter() const { return 0 != (attr_ & FLAG_HAS_BLOOM_FILTER); }
+    inline void inc_row_count() { ++row_count_; }
+    inline void set_row_count(int32_t row_count) { row_count_ = row_count; }
+    inline int32_t get_row_count() const { return row_count_; }
+    inline void set_per_key_bits(int32_t per_key_bits) { per_key_bits_ = per_key_bits; }
+    inline int32_t get_per_key_bits() const { return  per_key_bits_; }
+    inline void set_probe_num(int32_t probe_num) { probe_num_ = probe_num; }
+    inline int32_t get_probe_num() const { return probe_num_; }
+    inline void set_bloom_filter(const common::Slice &bloom_filter)
+    {
+      bloom_filter_ = bloom_filter;
+      set_has_bloom_filter();
+    }
+    inline const common::Slice &get_bloom_filter() const { return bloom_filter_; }
+    inline const std::vector<ColumnUnitInfo> &get_unit_infos() const { return unit_infos_; }
+    inline std::vector<ColumnUnitInfo> &get_unit_infos() { return unit_infos_; }
+    int64_t get_row_format_raw_size() const;
+
+    static const int32_t READ_CRITICAL_INFO_VERSION = 1;
+    DECLARE_SERIALIZATION()
+    DECLARE_AND_DEFINE_TO_STRING(KV_(handle), KV_(attr), KV_(per_key_bits), KV_(probe_num), KV_(unit_infos))
+  private:
+    static const int8_t FLAG_COLUMNAR_FORMAT = 0x01;
+    static const int8_t FLAG_HAS_BLOOM_FILTER = 0x02;
+
+  private:
+    BlockHandle handle_;
+    int8_t attr_;
+    int32_t row_count_;
+    int32_t per_key_bits_;
+    int32_t probe_num_;
+    common::Slice bloom_filter_;
+    std::vector<ColumnUnitInfo> unit_infos_;
+  };
 
 private:
-  BlockHandle handle_;
+  bool only_critical_info_;
+  ReadCriticalInfo critical_info_;
   std::string first_key_;
-  int32_t row_count_;
   int32_t delete_row_count_;
   int32_t single_delete_row_count_;
   common::SequenceNumber smallest_seq_;
   common::SequenceNumber largest_seq_;
-  int8_t attr_;
-  int32_t per_key_bits_;
-  int32_t probe_num_;
-  common::Slice bloom_filter_;
-  std::vector<ColumnUnitInfo> unit_infos_;
 };
 
 } // namespace table

--- a/storage/smartengine/core/table/extent_reader.cc
+++ b/storage/smartengine/core/table/extent_reader.cc
@@ -129,7 +129,7 @@ int ExtentReader::get(const Slice &key, GetContext *get_context)
     while (SUCCED(ret) && !done && index_block_reader.valid()) {
       block_info.reset();
       may_exist = true;
-      if (FAILED(index_block_reader.get_value(block_info))) {
+      if (FAILED(index_block_reader.get_value(true /*only_critical_info*/, block_info))) {
         SE_LOG(WARN, "fail to get block index", K(ret));
       } else if (block_info.has_bloom_filter() &&
                  FAILED(check_in_bloom_filter(get_context->get_user_key(), block_info, may_exist))) {
@@ -423,7 +423,7 @@ int ExtentReader::approximate_key_offet(const Slice &key, int64_t &offset)
   } else {
     index_block_reader.seek(key);
     if (index_block_reader.valid()) {
-      if (FAILED(index_block_reader.get_value(block_info))) {
+      if (FAILED(index_block_reader.get_value(true /*only_critical_info*/, block_info))) {
         SE_LOG(WARN, "fail to get block stats", K(ret));
       } else {
         offset = block_info.get_handle().get_offset();

--- a/storage/smartengine/core/table/index_block_reader.h
+++ b/storage/smartengine/core/table/index_block_reader.h
@@ -38,7 +38,7 @@ public:
   common::Slice key() const;
   common::Slice value() const;
   int get_key(common::Slice &key) const;
-  int get_value(BlockInfo &block_info) const;
+  int get_value(bool only_critical_info, BlockInfo &block_info) const;
   bool valid() const;
 
 private:

--- a/storage/smartengine/core/table/sstable_scan_iterator.cc
+++ b/storage/smartengine/core/table/sstable_scan_iterator.cc
@@ -325,7 +325,7 @@ int BlockPrefetchHelper::do_prefetch_data_block(const bool send_req_after_add)
   if (!index_block_iter_.Valid()) {
     ret = Status::kErrorUnexpected;
     SE_LOG(WARN, "the inde block iterator must be valid", K(ret));
-  } else if (FAILED(handle.block_info_.deserialize(index_block_iter_.value().data(), index_block_iter_.value().size(), pos))) {
+  } else if (FAILED(handle.block_info_.deserialize_critical_info(index_block_iter_.value().data(), index_block_iter_.value().size(), pos))) {
     SE_LOG(WARN, "fail to deserialize BlockInfo", K(ret));
   } else if (IS_NULL(extent_reader = index_extent_reader())) {
     ret = Status::kErrorUnexpected;

--- a/storage/smartengine/core/tools/sst_dump_tool.cc
+++ b/storage/smartengine/core/tools/sst_dump_tool.cc
@@ -108,7 +108,7 @@ int ExtentDumper::dump_index_block(RowBlock *index_block)
       BlockInfo block_info;
       if (FAILED(index_block_reader.get_key(internal_key))) {
         SE_LOG(WARN, "fail to get index key", K(ret));
-      } else if (FAILED(index_block_reader.get_value(block_info))) {
+      } else if (FAILED(index_block_reader.get_value(false , block_info))) {
         SE_LOG(WARN, "fail to get block stats", K(ret));
       } else if (!ParseInternalKey(internal_key, &parsed_internal_key)) {
         ret = Status::kCorruption;
@@ -155,7 +155,7 @@ int ExtentDumper::dump_all_data_block(RowBlock *index_block)
     while (SUCCED(ret) && index_block_reader.valid()) {
       if (FAILED(index_block_reader.get_key(last_key))) {
         SE_LOG(WARN, "fail to get index key", K(ret));
-      } else if (FAILED(index_block_reader.get_value(block_info))) {
+      } else if (FAILED(index_block_reader.get_value(false, block_info))) {
         SE_LOG(WARN, "fail to get block stats", K(ret));
       } else {
         Slice first_key(block_info.get_first_key());
@@ -260,7 +260,7 @@ int ExtentDumper::summry(const Footer &footer, RowBlock *index_block)
     while (SUCCED(ret) && index_block_reader.valid()) {
       if (FAILED(index_block_reader.get_key(key))) {
         SE_LOG(WARN, "fail to get index key", K(ret));
-      } else if (FAILED(index_block_reader.get_value(block_info))) {
+      } else if (FAILED(index_block_reader.get_value(false, block_info))) {
         SE_LOG(WARN, "fail to get block stats", K(ret));
       } else {
         extent_info.update(key, block_info);


### PR DESCRIPTION
Improved the efficiency of data reads by only deserializing critical information from block info, such as block handle and bloom filter, during read operations. Non-critical statistics and data are now omitted during the deserialization process, leading to lower CPU usage and faster read operations.

to #28 