### PR TITLE
feat: support replication from the source object storage.

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-wesql.result
+++ b/mysql-test/r/mysqld--help-notwin-wesql.result
@@ -113,9 +113,19 @@ The following options may be given as the first argument:
  If non-zero, persistent binlog will be purged after
  binlog_archive_expire_seconds seconds. If zero, all
  binlog will be retained.
+ --binlog-archive-parallel-workers=# 
+ Number of worker threads for uploading binlog slice to
+ object store in parallel
  --binlog-archive-period=# 
  binlog persist to object store at the given period
  milliseconds
+ --binlog-archive-replica 
+ Indicate if binlog archive replica enable.
+ --binlog-archive-replica-source-log-file=name 
+ The start source binlog file for snapshot archive replica
+ --binlog-archive-replica-source-log-pos=# 
+ The start source binlog file position for snapshot
+ archive replica
  --binlog-archive-slice-max-size=# 
  Binary log events will be persistent archived
  automatically when the size exceeds this value.
@@ -545,45 +555,12 @@ The following options may be given as the first argument:
  --init-slave=name   This option is deprecated. Use init_replica instead.
  -I, --initialize    Create the default database and exit. Create a super user
  with a random expired password and store it into the log.
- --initialize-branch-objectstore-id=name 
- The branch identifier for data directory of source
- cluster in object store.
- --initialize-from-objectstore 
- Initialzie instance using binlog and snapshot from object
- store.
+ --initialize-from-source-objectstore 
+ Initialzie instance using binlog and snapshot from source
+ object store.
  --initialize-insecure 
  Create the default database and exit. Create a super user
  with empty password.
- --initialize-objectstore-bucket=name 
- The object store bucket to store record as the source of
- data during instance initialization. If
- initialize_from_objectstore is true, it must not be
- empty.
- --initialize-objectstore-endpoint=name 
- The endpoint of object store as the source of data during
- instance initialization. If initialize_from_objectstore
- is true, user can specify the endpoint of object store.
- Ususally it's need to provide on non-AWS environment.
- --initialize-objectstore-provider=name 
- The provider of object store as the source of data during
- instance.If initialize_from_objectstore is true, it must
- not be empty.
- --initialize-objectstore-region=name 
- The region of object store as the source of data during
- instance initialization.If initialize_from_objectstore is
- true, it must not be empty.
- --initialize-objectstore-use-https 
- If initialize_from_objectstore is true, whether using
- https to connect to objstore or not as the source of data
- during instance initialization
- --initialize-repo-objectstore-id=name 
- The repo identifier for data directory of source cluster
- in object store. If initialize_from_objectstore is true,
- it must not be empty.
- --initialize-smartengine-objectstore-data 
- If initialize_from_objectstore is true, whether
- initialize smartengine object store data from source
- cluster object store.
  --interactive-timeout=# 
  The number of seconds the server waits for activity on an
  interactive connection before closing it
@@ -2055,6 +2032,31 @@ The following options may be given as the first argument:
  --sort-buffer-size=# 
  Each thread that needs to do a sort allocates a buffer of
  this size
+ --source-objectstore-branch-id=name 
+ The branch identifier for data directory of source
+ cluster in object store.
+ --source-objectstore-bucket=name 
+ The object store bucket to store record as the source of
+ data during instance initialization. 
+ --source-objectstore-endpoint=name 
+ The endpoint of object store as the source of data during
+ instance initialization. Ususally it's need to provide on
+ non-AWS environment.
+ --source-objectstore-provider=name 
+ The provider of object store as the source of data during
+ instance.
+ --source-objectstore-region=name 
+ The region of object store as the source of data during
+ instance initialization.
+ --source-objectstore-repo-id=name 
+ The repo identifier for data directory of source cluster
+ in object store. 
+ --source-objectstore-smartengine-data 
+ Whether initialize smartengine object store data from
+ source cluster object store.
+ --source-objectstore-use-https 
+ Whether using https to connect to objstore or not as the
+ source of data during instance initialization
  --source-verify-checksum 
  Force checksum verification of events in binary log
  before sending them to replicas or printing them in
@@ -2277,7 +2279,11 @@ binlog-archive TRUE
 binlog-archive-dir (No default value)
 binlog-archive-expire-auto-purge TRUE
 binlog-archive-expire-seconds 2592000
+binlog-archive-parallel-workers 4
 binlog-archive-period 1000
+binlog-archive-replica FALSE
+binlog-archive-replica-source-log-file (No default value)
+binlog-archive-replica-source-log-pos 4
 binlog-archive-slice-max-size 4194304
 binlog-archive-using-consensus-index TRUE
 binlog-cache-size 32768
@@ -2389,16 +2395,8 @@ init-file (No default value)
 init-replica 
 init-slave 
 initialize TRUE
-initialize-branch-objectstore-id main
-initialize-from-objectstore FALSE
+initialize-from-source-objectstore FALSE
 initialize-insecure TRUE
-initialize-objectstore-bucket objectstore_bucket_1
-initialize-objectstore-endpoint (No default value)
-initialize-objectstore-provider local
-initialize-objectstore-region local_objectstore_region_1
-initialize-objectstore-use-https FALSE
-initialize-repo-objectstore-id wesql_serverless_repo
-initialize-smartengine-objectstore-data FALSE
 interactive-timeout 28800
 internal-tmp-mem-storage-engine TempTable
 join-buffer-size 262144
@@ -2829,7 +2827,7 @@ smartengine-table-cache-size 1073741824
 smartengine-table-space ON
 smartengine-tables ON
 smartengine-total-max-shrink-extent-count 7680
-smartengine-total-memtable-size 107374182400
+smartengine-total-memtable-size 134217728
 smartengine-total-wal-size 134217728
 smartengine-trx ON
 smartengine-unsafe-for-binlog FALSE
@@ -2846,6 +2844,14 @@ snapshot-archive-period 300
 snapshot-archive-smartengine-backup-checkpoint FALSE
 snapshot-archive-smartengine-tar-mode OFF
 sort-buffer-size 262144
+source-objectstore-branch-id main
+source-objectstore-bucket objectstore_bucket_1
+source-objectstore-endpoint (No default value)
+source-objectstore-provider local
+source-objectstore-region .local_objectstore_region_1
+source-objectstore-repo-id wesql_serverless_repo
+source-objectstore-smartengine-data FALSE
+source-objectstore-use-https FALSE
 source-verify-checksum FALSE
 sporadic-binlog-dump-fail FALSE
 sql-generate-invisible-primary-key FALSE

--- a/mysql-test/suite/smartengine_consistent_snapshot/r/consistent_snapshot_ro_replica-wesql.result
+++ b/mysql-test/suite/smartengine_consistent_snapshot/r/consistent_snapshot_ro_replica-wesql.result
@@ -1,0 +1,88 @@
+# Wait for at least 1 snapshots to be generated 
+CREATE TABLE t1(c1 int) ENGINE=SMARTENGINE ;
+INSERT INTO t1 values(1);
+INSERT INTO t1 values(2);
+INSERT INTO t1 values(3);
+INSERT INTO t1 values(4);
+INSERT INTO t1 values(5);
+SELECT SNAPSHOT_ARCHIVE_PERSISTENT_FORCE();
+SNAPSHOT_ARCHIVE_PERSISTENT_FORCE()
+
+# Wait for at least 2 snapshots to be generated 
+INSERT INTO t1 values(6);
+INSERT INTO t1 values(7);
+INSERT INTO t1 values(8);
+INSERT INTO t1 values(9);
+INSERT INTO t1 values(10);
+INSERT INTO t1 values(11);
+INSERT INTO t1 values(12);
+INSERT INTO t1 values(13);
+INSERT INTO t1 values(14);
+INSERT INTO t1 values(15);
+INSERT INTO t1 values(16);
+INSERT INTO t1 values(17);
+INSERT INTO t1 values(18);
+INSERT INTO t1 values(19);
+INSERT INTO t1 values(20);
+SELECT count(*) FROM t1;
+count(*)
+20
+# Wait for all binlog persistent
+# clone database ro
+# Initialize ro server
+# Start ro server
+# Wait ro accept connection
+# Wait ro changed leader
+# Connection ro
+SELECT count(*) FROM t1;
+count(*)
+20
+# Connection master for insert
+# Insert values
+INSERT INTO t1 values(21);
+INSERT INTO t1 values(22);
+INSERT INTO t1 values(23);
+INSERT INTO t1 values(24);
+INSERT INTO t1 values(25);
+SELECT count(*) FROM t1;
+count(*)
+25
+# Connection ro for checking binlog replication
+SELECT count(*) FROM t1;
+count(*)
+25
+# Shutdown ro
+# Connection master for insert values
+# Insert values into master
+INSERT INTO t1 values(26);
+INSERT INTO t1 values(27);
+INSERT INTO t1 values(28);
+INSERT INTO t1 values(29);
+INSERT INTO t1 values(30);
+SELECT count(*) FROM t1;
+count(*)
+30
+# Restart ro for binlog continuous replication
+# Wait ro accept reconnection
+# Check ro binlog replication
+SELECT count(*) FROM t1;
+count(*)
+30
+# Connection master for insert values
+# Insert values
+INSERT INTO t1 values(31);
+INSERT INTO t1 values(32);
+INSERT INTO t1 values(33);
+INSERT INTO t1 values(34);
+INSERT INTO t1 values(35);
+SELECT count(*) FROM t1;
+count(*)
+35
+# Connection ro for checking binlog replication
+SELECT count(*) FROM t1;
+count(*)
+35
+# Shutdown ro
+# Cleanup ro
+# Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_clone.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_clone.test
@@ -41,7 +41,7 @@ let MYSQLD_DATADIR = $tmp_dir/snapshot_clone_ro_test;
 let MYSQLD_ERROR_LOG = $tmp_dir/ro_boost.err;
 let MYSQLD_ERROR_START_LOG = $tmp_dir/ro_start.err;
 let self_bucket=wesql-ro;
-let MYSQLD_EXTRA_INIT_ARGS = --initialize_from_objectstore=true --initialize_smartengine_objectstore_data=true --initialize_objectstore_region=$source_region --initialize_objectstore_bucket=$source_bucket --initialize_repo_objectstore_id=$source_repo --objectstore_bucket=$self_bucket;
+let MYSQLD_EXTRA_INIT_ARGS = --initialize_from_source_objectstore=true --source_objectstore_smartengine_data=true --source_objectstore_region=$source_region --source_objectstore_bucket=$source_bucket --source_objectstore_repo_id=$source_repo --objectstore_bucket=$self_bucket;
 
 --echo # Initialize ro server
 let $MYSQLD_EXTRA_ARGS = --port=$ro_port --socket=$MYSQLD_DATADIR/test.sock --console --skip-ssl --log-bin=master-bin --objectstore-region=.local_region --objectstore_bucket=$self_bucket --log-error-verbosity=3 --datadir=$MYSQLD_DATADIR;
@@ -120,7 +120,7 @@ let MYSQLD_INNODB_WAL_DIR = $MYSQLD_LOG_DIR;
 let MYSQLD_SE_SST_DATADIR = $MYSQLD_LOG_DIR/smartengine_sst;
 let MYSQLD_SE_WAL_DIR = $MYSQLD_LOG_DIR/smartengine_wal;
 
-let MYSQLD_EXTRA_INIT_ARGS = --initialize_from_objectstore=true --initialize_smartengine_objectstore_data=true --initialize_objectstore_region=$source_region --initialize_objectstore_bucket=$source_bucket --initialize_repo_objectstore_id=$source_repo --objectstore_bucket=$self_bucket;
+let MYSQLD_EXTRA_INIT_ARGS = --initialize_from_source_objectstore=true --source_objectstore_smartengine_data=true --source_objectstore_region=$source_region --source_objectstore_bucket=$source_bucket --source_objectstore_repo_id=$source_repo --objectstore_bucket=$self_bucket;
 
 --echo # Initialize ro2 server
 let $MYSQLD_EXTRA_ARGS = --port=$ro2_port --socket=$MYSQLD_DATADIR/test.sock --console --skip-ssl --log-bin=$MYSQLD_BINLOG_DIR --objectstore-region=.local_region --objectstore_bucket=$self_bucket --log-error-verbosity=3 --datadir=$MYSQLD_DATADIR --innodb_log_group_home_dir=$MYSQLD_INNODB_WAL_DIR --smartengine_data_dir=$MYSQLD_SE_SST_DATADIR --smartengine_wal_dir=$MYSQLD_SE_WAL_DIR;

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica-master.opt
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica-master.opt
@@ -1,0 +1,1 @@
+--initialize=--objectstore-region=$MYSQL_TMP_DIR

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica.cnf
@@ -1,0 +1,9 @@
+!include suite/smartengine_consistent_snapshot/my.cnf
+
+[mysqld]
+log-bin=                    master-bin
+binlog_format=              ROW
+sync_binlog=                1
+snapshot_archive_expire_auto_purge=  false
+binlog_archive_expire_auto_purge=       false
+binlog_archive_period=                  1000

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica.cnf
@@ -7,3 +7,4 @@ sync_binlog=                1
 snapshot_archive_expire_auto_purge=  false
 binlog_archive_expire_auto_purge=       false
 binlog_archive_period=                  1000
+objectstore_lease_lock_timeout=         0

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica.test
@@ -1,0 +1,192 @@
+#
+# Test for RO replica incremental binlog from source object store
+#
+
+--echo # Wait for at least 1 snapshots to be generated 
+let $wait_condition= SELECT count(*) >=1 FROM INFORMATION_SCHEMA.SNAPSHOT_PERSISTENT_SNAPSHOT_INDEX;
+--source include/wait_condition_or_abort.inc
+
+CREATE TABLE t1(c1 int) ENGINE=SMARTENGINE ;
+INSERT INTO t1 values(1);
+INSERT INTO t1 values(2);
+INSERT INTO t1 values(3);
+INSERT INTO t1 values(4);
+INSERT INTO t1 values(5);
+
+--let $source_region = `select @@objectstore_region`
+--let $source_bucket=`select @@objectstore_bucket`
+--let $source_repo = `select @@repo_objectstore_id`
+--let $source_server_id= `SELECT @@server_id`
+--let $source_port= `SELECT @@port`
+
+SELECT SNAPSHOT_ARCHIVE_PERSISTENT_FORCE();
+
+--echo # Wait for at least 2 snapshots to be generated 
+let $wait_condition= SELECT count(*) >=2 FROM INFORMATION_SCHEMA.SNAPSHOT_PERSISTENT_SNAPSHOT_INDEX;
+--source include/wait_condition_or_abort.inc
+
+INSERT INTO t1 values(6);
+INSERT INTO t1 values(7);
+INSERT INTO t1 values(8);
+INSERT INTO t1 values(9);
+INSERT INTO t1 values(10);
+INSERT INTO t1 values(11);
+INSERT INTO t1 values(12);
+INSERT INTO t1 values(13);
+INSERT INTO t1 values(14);
+INSERT INTO t1 values(15);
+INSERT INTO t1 values(16);
+INSERT INTO t1 values(17);
+INSERT INTO t1 values(18);
+INSERT INTO t1 values(19);
+INSERT INTO t1 values(20);
+SELECT count(*) FROM t1;
+
+--echo # Wait for all binlog persistent
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO, INFORMATION_SCHEMA.WESQL_CLUSTER_LOCAL where LAST_PERSISTED_RAFT_INDEX = COMMIT_INDEX;
+let $wait_timeout= 600;
+--source include/wait_condition_or_abort.inc
+
+--echo # clone database ro
+let $ro_server_id = query_get_value("select $source_server_id+10 as c1", c1, 1);
+let $ro_port = query_get_value("select $source_port+988 as c1", c1, 1);
+let $tmp_dir = $MYSQLTEST_VARDIR/tmp;
+let MYSQLD_DATADIR = $tmp_dir/snapshot_clone_ro_test;
+let MYSQLD_ERROR_LOG = $MYSQLTEST_VARDIR/log/ro_boost.err;
+let MYSQLD_ERROR_START_LOG = $MYSQLTEST_VARDIR/log/ro_start.err;
+let self_bucket=wesql-ro;
+let MYSQLD_EXTRA_INIT_ARGS = --initialize_from_source_objectstore=true; 
+--echo # Initialize ro server
+let $MYSQLD_EXTRA_ARGS = --server-id=$ro_server_id --port=$ro_port --socket=$MYSQLD_DATADIR/test.sock --console --skip-ssl --log-bin=master-bin --objectstore-region=.local_region --objectstore_bucket=$self_bucket --log-error-verbosity=3 --datadir=$MYSQLD_DATADIR --source_objectstore_smartengine_data=true --source_objectstore_region=$source_region --source_objectstore_bucket=$source_bucket --source_objectstore_repo_id=$source_repo --objectstore_bucket=$self_bucket;
+--exec $MYSQLD --initialize-insecure --no-defaults $MYSQLD_ARGS $MYSQLD_EXTRA_INIT_ARGS $MYSQLD_EXTRA_ARGS > $MYSQLD_ERROR_LOG 2>&1
+--echo # Start ro server
+
+--write_file $tmp_dir/snapshot_clone_ro_test/my.cnf
+[mysqld]
+binlog_archive_replica=ON
+relay_log_recovery=on
+binlog_archive=OFF
+snapshot_archive=OFF
+sync_binlog=1
+sync_relay_log=1
+relay_log=relay-bin
+binlog_format=ROW
+EOF
+
+let $ro_cluster_info= '127.0.0.1:19981@1';
+--exec $MYSQLD --defaults-file=$tmp_dir/snapshot_clone_ro_test/my.cnf $MYSQLD_ARGS $MYSQLD_EXTRA_ARGS --raft-replication-force-change-meta=ON --raft-replication-cluster-info=$ro_cluster_info --log-error=$MYSQLD_ERROR_START_LOG 2>&1 &
+
+--echo # Wait ro accept connection
+--disable_abort_on_error
+--disable_query_log
+--disable_result_log
+--let $mysql_errno= 9999
+--let $wait_counter= 300
+while ($mysql_errno)
+{
+  connect (ro,127.0.0.1,root,,test,$ro_port);
+  if ($mysql_errno == 1045){
+    --let mysql_errno=0
+  }
+  if ($mysql_errname == ER_SECURE_TRANSPORT_REQUIRED){
+    --let mysql_errno=0
+  }
+  if ($mysql_errno){
+    --sleep 0.1
+    --dec $wait_counter
+    if (!$wait_counter){
+      --die Server failed to connect new ro node
+    }
+  }
+}
+--enable_result_log
+--enable_query_log
+--enable_abort_on_error
+
+--echo # Wait ro changed leader
+let $wait_timeout= 60;
+let $wait_condition= select count(*)=1 from information_schema.wesql_cluster_local where role='leader';
+--source include/wait_condition.inc
+
+--echo # Connection ro
+--connection ro
+SELECT count(*) FROM t1;
+
+--echo # Connection master for insert
+--connection default
+--echo # Insert values
+INSERT INTO t1 values(21);
+INSERT INTO t1 values(22);
+INSERT INTO t1 values(23);
+INSERT INTO t1 values(24);
+INSERT INTO t1 values(25);
+SELECT count(*) FROM t1;
+--let $master_count = `SELECT count(*) FROM t1;`
+
+--echo # Connection ro for checking binlog replication
+--connection ro
+let $wait_timeout= 60;
+let $wait_condition= SELECT count(*)=$master_count FROM t1;
+--source include/wait_condition.inc
+SELECT count(*) FROM t1;
+
+--echo # Shutdown ro
+--shutdown_server 0
+--source include/wait_until_disconnected.inc
+
+--echo # Connection master for insert values
+--connection default
+--echo # Insert values into master
+INSERT INTO t1 values(26);
+INSERT INTO t1 values(27);
+INSERT INTO t1 values(28);
+INSERT INTO t1 values(29);
+INSERT INTO t1 values(30);
+SELECT count(*) FROM t1;
+--let $master_count = `SELECT count(*) FROM t1;`
+
+--echo # Restart ro for binlog continuous replication
+--exec $MYSQLD --defaults-file=$tmp_dir/snapshot_clone_ro_test/my.cnf $MYSQLD_ARGS $MYSQLD_EXTRA_ARGS --raft-replication-force-change-meta=ON --raft-replication-cluster-info=$ro_cluster_info --log-error=$MYSQLD_ERROR_START_LOG 2>&1 &
+
+--echo # Wait ro accept reconnection
+--connection ro
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+
+--echo # Check ro binlog replication
+let $wait_timeout= 60;
+let $wait_condition= SELECT count(*)=$master_count FROM t1;
+--source include/wait_condition.inc
+SELECT count(*) FROM t1;
+
+--echo # Connection master for insert values
+--connection default
+--echo # Insert values
+INSERT INTO t1 values(31);
+INSERT INTO t1 values(32);
+INSERT INTO t1 values(33);
+INSERT INTO t1 values(34);
+INSERT INTO t1 values(35);
+SELECT count(*) FROM t1;
+--let $master_count = `SELECT count(*) FROM t1;`
+
+--echo # Connection ro for checking binlog replication
+--connection ro
+let $wait_timeout= 60;
+let $wait_condition= SELECT count(*)=$master_count FROM t1;
+--source include/wait_condition.inc
+SELECT count(*) FROM t1;
+
+--echo # Shutdown ro
+--shutdown_server 0
+--source include/wait_until_disconnected.inc
+
+--echo # Cleanup ro
+--force-rmdir $MYSQLD_DATADIR
+--remove_file $MYSQLD_ERROR_LOG
+--remove_file $MYSQLD_ERROR_START_LOG
+
+--connection default
+
+--echo # Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/consistent_snapshot_ro_replica.test
@@ -63,14 +63,16 @@ let $MYSQLD_EXTRA_ARGS = --server-id=$ro_server_id --port=$ro_port --socket=$MYS
 
 --write_file $tmp_dir/snapshot_clone_ro_test/my.cnf
 [mysqld]
-binlog_archive_replica=ON
-relay_log_recovery=on
-binlog_archive=OFF
-snapshot_archive=OFF
 sync_binlog=1
 sync_relay_log=1
 relay_log=relay-bin
 binlog_format=ROW
+relay_log_recovery=on
+objectstore_lease_lock_timeout=0
+binlog_archive_replica=ON
+snapshot_archive_expire_auto_purge=false
+binlog_archive_expire_auto_purge=false
+binlog_archive_period=1000
 EOF
 
 let $ro_cluster_info= '127.0.0.1:19981@1';

--- a/patches/mysql-server-8.0.35.patch
+++ b/patches/mysql-server-8.0.35.patch
@@ -2751,7 +2751,7 @@ index e010b378799..a6f94f8f194 100644
  ################################################################################
  # DO NOT add messages for the error-log to this file;
 diff --git a/share/messages_to_error_log.txt b/share/messages_to_error_log.txt
-index cdef214ae5f..2f1f0545876 100644
+index cdef214ae5f..8010a9a6236 100644
 --- a/share/messages_to_error_log.txt
 +++ b/share/messages_to_error_log.txt
 @@ -12293,6 +12293,459 @@ ER_WARN_DEPRECATED_OR_BLOCKED_CIPHER
@@ -3172,7 +3172,7 @@ index cdef214ae5f..2f1f0545876 100644
 +  eng "Binlog archive replica: %s."
 +
 +ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER
-+  eng "Binlog archive replica replay worker: %s."
++  eng "Binlog archive replica relay worker: %s."
 +
 +ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER
 +  eng "Binlog archive replica io worker %d: %s."
@@ -4684,7 +4684,7 @@ index c288026b810..22d6c7b9d24 100644
  
  #endif /* _log_event_h */
 diff --git a/sql/mysqld.cc b/sql/mysqld.cc
-index 3f94e768956..17d146270c6 100644
+index 3f94e768956..7c554929ddb 100644
 --- a/sql/mysqld.cc
 +++ b/sql/mysqld.cc
 @@ -774,15 +774,19 @@ MySQL clients support the protocol:
@@ -4732,7 +4732,7 @@ index 3f94e768956..17d146270c6 100644
  bool opt_initialize = false;
  bool opt_skip_replica_start = false;  ///< If set, slave is not autostarted
  bool opt_enable_named_pipe = false;
-@@ -1500,6 +1511,68 @@ char server_version[SERVER_VERSION_LENGTH];
+@@ -1500,6 +1511,69 @@ char server_version[SERVER_VERSION_LENGTH];
  const char *mysqld_unix_port;
  char *opt_mysql_tmpdir;
  
@@ -4756,6 +4756,7 @@ index 3f94e768956..17d146270c6 100644
 +ulonglong opt_binlog_archive_period = 0;
 +ulong opt_binlog_archive_parallel_workers = 0;
 +bool opt_binlog_archive_replica = false;
++ulong opt_binlog_archive_replica_flush_period = 0;
 +char *opt_binlog_archive_replica_source_log_file = nullptr;
 +ulong opt_binlog_archive_replica_source_log_pos = 0;
 +char *opt_consistent_snapshot_archive_dir = nullptr;
@@ -4801,7 +4802,7 @@ index 3f94e768956..17d146270c6 100644
  char *opt_authentication_policy;
  std::vector<std::string> authentication_policy_list;
  /*
-@@ -2362,6 +2435,12 @@ static void close_connections(void) {
+@@ -2362,6 +2436,12 @@ static void close_connections(void) {
    Call_close_conn call_close_conn(true);
    thd_manager->do_for_all_thd(&call_close_conn);
  
@@ -4814,7 +4815,7 @@ index 3f94e768956..17d146270c6 100644
    (void)RUN_HOOK(server_state, after_server_shutdown, (nullptr));
  
    /*
-@@ -2493,6 +2572,9 @@ void clean_up_mysqld_mutexes() { clean_up_mutexes(); }
+@@ -2493,6 +2573,9 @@ void clean_up_mysqld_mutexes() { clean_up_mutexes(); }
  static void mysqld_exit(int exit_code) {
    assert((exit_code >= MYSQLD_SUCCESS_EXIT && exit_code <= MYSQLD_ABORT_EXIT) ||
           exit_code == MYSQLD_RESTART_EXIT);
@@ -4824,7 +4825,7 @@ index 3f94e768956..17d146270c6 100644
    mysql_audit_finalize();
    Srv_session::module_deinit();
    delete_optimizer_cost_module();
-@@ -4272,6 +4354,10 @@ SHOW_VAR com_status_vars[] = {
+@@ -4272,6 +4355,10 @@ SHOW_VAR com_status_vars[] = {
       (char *)offsetof(System_status_var,
                        com_stat[(uint)SQLCOM_SHOW_BINLOG_EVENTS]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4835,7 +4836,7 @@ index 3f94e768956..17d146270c6 100644
      {"show_binlogs",
       (char *)offsetof(System_status_var, com_stat[(uint)SQLCOM_SHOW_BINLOGS]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
-@@ -4443,6 +4529,14 @@ SHOW_VAR com_status_vars[] = {
+@@ -4443,6 +4530,14 @@ SHOW_VAR com_status_vars[] = {
       (char *)offsetof(System_status_var,
                        com_stat[(uint)SQLCOM_STOP_GROUP_REPLICATION]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4850,7 +4851,7 @@ index 3f94e768956..17d146270c6 100644
      {"stmt_execute", (char *)offsetof(System_status_var, com_stmt_execute),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
      {"stmt_close", (char *)offsetof(System_status_var, com_stmt_close),
-@@ -4498,6 +4592,16 @@ SHOW_VAR com_status_vars[] = {
+@@ -4498,6 +4593,16 @@ SHOW_VAR com_status_vars[] = {
      {"xa_start",
       (char *)offsetof(System_status_var, com_stat[(uint)SQLCOM_XA_START]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4867,7 +4868,7 @@ index 3f94e768956..17d146270c6 100644
      {NullS, NullS, SHOW_LONG, SHOW_SCOPE_ALL}};
  
  LEX_CSTRING sql_statement_names[(uint)SQLCOM_END + 1];
-@@ -4817,6 +4921,10 @@ int init_common_variables() {
+@@ -4817,6 +4922,10 @@ int init_common_variables() {
    */
    mysql_bin_log.init_pthread_objects();
  
@@ -4878,7 +4879,7 @@ index 3f94e768956..17d146270c6 100644
    /* TODO: remove this when my_time_t is 64 bit compatible */
    if (!is_time_t_valid_for_timestamp(server_start_time)) {
      LogErr(ERROR_LEVEL, ER_UNSUPPORTED_DATE);
-@@ -4859,6 +4967,12 @@ int init_common_variables() {
+@@ -4859,6 +4968,12 @@ int init_common_variables() {
    default_storage_engine = "InnoDB";
    default_tmp_storage_engine = default_storage_engine;
  
@@ -4891,7 +4892,7 @@ index 3f94e768956..17d146270c6 100644
    /*
      Add server status variables to the dynamic list of
      status variables that is shown by SHOW STATUS.
-@@ -6286,6 +6400,14 @@ static int init_server_components() {
+@@ -6286,6 +6401,14 @@ static int init_server_components() {
        opt_bin_logname = my_strdup(key_memory_opt_bin_logname, buf, MYF(0));
      }
  
@@ -4906,7 +4907,7 @@ index 3f94e768956..17d146270c6 100644
      /*
        Skip opening the index file if we start with --help. This is necessary
        to avoid creating the file in an otherwise empty datadir, which will
-@@ -6503,6 +6625,33 @@ static int init_server_components() {
+@@ -6503,6 +6626,33 @@ static int init_server_components() {
        LogErr(ERROR_LEVEL, ER_CANT_INITIALIZE_BUILTIN_PLUGINS);
      unireg_abort(1);
    }
@@ -4940,7 +4941,7 @@ index 3f94e768956..17d146270c6 100644
  
    /*
      Needs to be done before dd::init() which runs DDL commands (for real)
-@@ -6785,6 +6934,27 @@ static int init_server_components() {
+@@ -6785,6 +6935,27 @@ static int init_server_components() {
      unireg_abort(1);
    }
  
@@ -4968,7 +4969,7 @@ index 3f94e768956..17d146270c6 100644
    if (opt_initialize) log_output_options = LOG_FILE;
  
    /*
-@@ -6818,6 +6988,20 @@ static int init_server_components() {
+@@ -6818,6 +6989,20 @@ static int init_server_components() {
    /*
      Set the default storage engines
    */
@@ -4989,7 +4990,7 @@ index 3f94e768956..17d146270c6 100644
    if (initialize_storage_engine(default_storage_engine, "",
                                  &global_system_variables.table_plugin))
      unireg_abort(MYSQLD_ABORT_EXIT);
-@@ -6890,7 +7074,22 @@ static int init_server_components() {
+@@ -6890,7 +7075,22 @@ static int init_server_components() {
      unireg_abort(MYSQLD_ABORT_EXIT);
    }
  
@@ -5013,7 +5014,7 @@ index 3f94e768956..17d146270c6 100644
      /*
        Configures what object is used by the current log to store processed
        gtid(s). This is necessary in the MYSQL_BIN_LOG::MYSQL_BIN_LOG to
-@@ -7531,6 +7730,11 @@ int mysqld_main(int argc, char **argv)
+@@ -7531,6 +7731,11 @@ int mysqld_main(int argc, char **argv)
    */
    init_server_psi_keys();
  
@@ -5025,7 +5026,7 @@ index 3f94e768956..17d146270c6 100644
    /*
      Now that some instrumentation is in place,
      recreate objects which were initialised early,
-@@ -7818,6 +8022,16 @@ int mysqld_main(int argc, char **argv)
+@@ -7818,6 +8023,16 @@ int mysqld_main(int argc, char **argv)
      unireg_abort(exit_state);
    }
  
@@ -5042,7 +5043,7 @@ index 3f94e768956..17d146270c6 100644
    /*
     We have enough space for fiddling with the argv, continue
    */
-@@ -7830,6 +8044,63 @@ int mysqld_main(int argc, char **argv)
+@@ -7830,6 +8045,63 @@ int mysqld_main(int argc, char **argv)
      unireg_abort(MYSQLD_ABORT_EXIT); /* purecov: inspected */
    }
  
@@ -5106,7 +5107,7 @@ index 3f94e768956..17d146270c6 100644
    /*
     The subsequent calls may take a long time : e.g. innodb log read.
     Thus set the long running service control manager timeout
-@@ -7879,6 +8150,16 @@ int mysqld_main(int argc, char **argv)
+@@ -7879,6 +8151,16 @@ int mysqld_main(int argc, char **argv)
      if (gtid_state->read_gtid_executed_from_table() == -1) unireg_abort(1);
    }
  
@@ -5123,7 +5124,7 @@ index 3f94e768956..17d146270c6 100644
    if (opt_bin_log) {
      /*
        Initialize GLOBAL.GTID_EXECUTED and GLOBAL.GTID_PURGED from
-@@ -7998,6 +8279,14 @@ int mysqld_main(int argc, char **argv)
+@@ -7998,6 +8280,14 @@ int mysqld_main(int argc, char **argv)
      (void)RUN_HOOK(server_state, after_engine_recovery, (nullptr));
    }
  
@@ -5138,7 +5139,7 @@ index 3f94e768956..17d146270c6 100644
    if (init_ssl_communication()) unireg_abort(MYSQLD_ABORT_EXIT);
    if (network_init()) unireg_abort(MYSQLD_ABORT_EXIT);
  
-@@ -8133,8 +8422,22 @@ int mysqld_main(int argc, char **argv)
+@@ -8133,8 +8423,22 @@ int mysqld_main(int argc, char **argv)
  
    initialize_information_schema_acl();
  
@@ -5161,7 +5162,7 @@ index 3f94e768956..17d146270c6 100644
    if (Events::init(opt_noacl || opt_initialize))
      unireg_abort(MYSQLD_ABORT_EXIT);
  
-@@ -8158,6 +8461,13 @@ int mysqld_main(int argc, char **argv)
+@@ -8158,6 +8462,13 @@ int mysqld_main(int argc, char **argv)
      return 1;
    }
  
@@ -5175,7 +5176,7 @@ index 3f94e768956..17d146270c6 100644
    /*
      Invoke the bootstrap thread, if required.
    */
-@@ -9267,6 +9577,12 @@ struct my_option my_long_options[] = {
+@@ -9267,6 +9578,12 @@ struct my_option my_long_options[] = {
       &opt_upgrade_mode, &opt_upgrade_mode, &upgrade_mode_typelib, GET_ENUM,
       REQUIRED_ARG, UPGRADE_AUTO, 0, 0, nullptr, 0, nullptr},
  
@@ -5188,7 +5189,7 @@ index 3f94e768956..17d146270c6 100644
      {nullptr, 0, nullptr, nullptr, nullptr, nullptr, GET_NO_ARG, NO_ARG, 0, 0,
       0, nullptr, 0, nullptr}};
  
-@@ -11131,6 +11447,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
+@@ -11131,6 +11448,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
  #ifndef _WIN32
    if (mysqld_chroot) set_root(mysqld_chroot);
  #endif
@@ -5196,7 +5197,7 @@ index 3f94e768956..17d146270c6 100644
    if (fix_paths()) return 1;
  
    /*
-@@ -11184,6 +11501,11 @@ static void set_server_version(void) {
+@@ -11184,6 +11502,11 @@ static void set_server_version(void) {
  #ifndef NDEBUG
    if (!strstr(MYSQL_SERVER_SUFFIX_STR, "-debug"))
      end = my_stpcpy(end, "-debug");
@@ -5208,7 +5209,7 @@ index 3f94e768956..17d146270c6 100644
  #endif
  #ifdef HAVE_VALGRIND
    if (SERVER_VERSION_LENGTH - (end - server_version) >
-@@ -11795,6 +12117,13 @@ PSI_mutex_key key_monitor_info_run_lock;
+@@ -11795,6 +12118,13 @@ PSI_mutex_key key_monitor_info_run_lock;
  PSI_mutex_key key_LOCK_delegate_connection_mutex;
  PSI_mutex_key key_LOCK_group_replication_connection_mutex;
  
@@ -5222,7 +5223,7 @@ index 3f94e768956..17d146270c6 100644
  /* clang-format off */
  static PSI_mutex_info all_server_mutexes[]=
  {
-@@ -11861,6 +12190,12 @@ static PSI_mutex_info all_server_mutexes[]=
+@@ -11861,6 +12191,12 @@ static PSI_mutex_info all_server_mutexes[]=
    { &key_mutex_slave_parallel_pend_jobs, "Relay_log_info::pending_jobs_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_mutex_slave_parallel_worker_count, "Relay_log_info::exit_count_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_mutex_slave_parallel_worker, "Worker_info::jobs_lock", 0, 0, PSI_DOCUMENT_ME},
@@ -5235,7 +5236,7 @@ index 3f94e768956..17d146270c6 100644
    { &key_TABLE_SHARE_LOCK_ha_data, "TABLE_SHARE::LOCK_ha_data", 0, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_error_messages, "LOCK_error_messages", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_log_throttle_qni, "LOCK_log_throttle_qni", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
-@@ -11887,7 +12222,7 @@ static PSI_mutex_info all_server_mutexes[]=
+@@ -11887,7 +12223,7 @@ static PSI_mutex_info all_server_mutexes[]=
    { &key_monitor_info_run_lock, "Source_IO_monitor::run_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_delegate_connection_mutex, "LOCK_delegate_connection_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_group_replication_connection_mutex, "LOCK_group_replication_connection_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
@@ -5244,7 +5245,7 @@ index 3f94e768956..17d146270c6 100644
    { &key_LOCK_global_conn_mem_limit, "LOCK_global_conn_mem_limit", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME}
  };
  /* clang-format on */
-@@ -11906,6 +12241,14 @@ PSI_rwlock_key key_rwlock_Binlog_transmit_delegate_lock;
+@@ -11906,6 +12242,14 @@ PSI_rwlock_key key_rwlock_Binlog_transmit_delegate_lock;
  PSI_rwlock_key key_rwlock_Binlog_relay_IO_delegate_lock;
  PSI_rwlock_key key_rwlock_resource_group_mgr_map_lock;
  
@@ -5259,7 +5260,7 @@ index 3f94e768956..17d146270c6 100644
  /* clang-format off */
  static PSI_rwlock_info all_server_rwlocks[]=
  {
-@@ -11922,6 +12265,13 @@ static PSI_rwlock_info all_server_rwlocks[]=
+@@ -11922,6 +12266,13 @@ static PSI_rwlock_info all_server_rwlocks[]=
    { &key_rwlock_Trans_delegate_lock, "Trans_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_Server_state_delegate_lock, "Server_state_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_Binlog_storage_delegate_lock, "Binlog_storage_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
@@ -5273,7 +5274,7 @@ index 3f94e768956..17d146270c6 100644
    { &key_rwlock_receiver_sid_lock, "gtid_retrieved", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_rpl_filter_lock, "rpl_filter_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_channel_to_filter_lock, "channel_to_filter_lock", 0, 0, PSI_DOCUMENT_ME},
-@@ -11960,6 +12310,12 @@ PSI_cond_key key_cond_slave_worker_hash;
+@@ -11960,6 +12311,12 @@ PSI_cond_key key_cond_slave_worker_hash;
  PSI_cond_key key_monitor_info_run_cond;
  PSI_cond_key key_COND_delegate_connection_cond_var;
  PSI_cond_key key_COND_group_replication_connection_cond_var;
@@ -5286,7 +5287,7 @@ index 3f94e768956..17d146270c6 100644
  
  /* clang-format off */
  static PSI_cond_info all_server_conds[]=
-@@ -11997,6 +12353,12 @@ static PSI_cond_info all_server_conds[]=
+@@ -11997,6 +12354,12 @@ static PSI_cond_info all_server_conds[]=
    { &key_cond_slave_parallel_pend_jobs, "Relay_log_info::pending_jobs_cond", 0, 0, PSI_DOCUMENT_ME},
    { &key_cond_slave_parallel_worker, "Worker_info::jobs_cond", 0, 0, PSI_DOCUMENT_ME},
    { &key_cond_mta_gaq, "Relay_log_info::mta_gaq_cond", 0, 0, PSI_DOCUMENT_ME},
@@ -5300,7 +5301,7 @@ index 3f94e768956..17d146270c6 100644
    { &key_COND_compress_gtid_table, "COND_compress_gtid_table", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_commit_order_manager_cond, "Commit_order_manager::m_workers.cond", 0, 0, PSI_DOCUMENT_ME},
 diff --git a/sql/mysqld.h b/sql/mysqld.h
-index 8b5a842b54b..32ac050fe84 100644
+index 8b5a842b54b..cd8153d8e89 100644
 --- a/sql/mysqld.h
 +++ b/sql/mysqld.h
 @@ -180,6 +180,9 @@ extern MYSQL_PLUGIN_IMPORT std::atomic<int32>
@@ -5336,7 +5337,7 @@ index 8b5a842b54b..32ac050fe84 100644
  #endif /* HAVE_PSI_INTERFACE */
  
  /*
-@@ -698,6 +717,59 @@ extern MYSQL_PLUGIN_IMPORT char pidfile_name[];
+@@ -698,6 +717,60 @@ extern MYSQL_PLUGIN_IMPORT char pidfile_name[];
  
  #define mysql_tmpdir (my_tmpdir(&mysql_tmpdir_list))
  
@@ -5358,6 +5359,7 @@ index 8b5a842b54b..32ac050fe84 100644
 +extern ulonglong opt_binlog_archive_period;
 +extern ulong opt_binlog_archive_parallel_workers;
 +extern bool opt_binlog_archive_replica;
++extern ulong opt_binlog_archive_replica_flush_period;
 +extern char *opt_binlog_archive_replica_source_log_file;
 +extern ulong opt_binlog_archive_replica_source_log_pos;
 +extern char *opt_consistent_snapshot_archive_dir;
@@ -9323,7 +9325,7 @@ index 6c3dd85db23..8c43a67cd52 100644
          | HASH_SYM
          | HISTOGRAM_SYM
 diff --git a/sql/sys_vars.cc b/sql/sys_vars.cc
-index b16cb1830e4..9924d84a1b7 100644
+index b16cb1830e4..8f4f68feae9 100644
 --- a/sql/sys_vars.cc
 +++ b/sql/sys_vars.cc
 @@ -93,11 +93,13 @@
@@ -9419,7 +9421,7 @@ index b16cb1830e4..9924d84a1b7 100644
  
  static bool check_set_require_row_format(sys_var *, THD *thd, set_var *var) {
    /*
-@@ -7718,3 +7764,306 @@ static Sys_var_enum Sys_explain_format(
+@@ -7718,3 +7764,313 @@ static Sys_var_enum Sys_explain_format(
      SESSION_VAR(explain_format), CMD_LINE(OPT_ARG), explain_format_names,
      DEFAULT(static_cast<ulong>(Explain_format_type::TRADITIONAL)),
      NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr));
@@ -9485,9 +9487,16 @@ index b16cb1830e4..9924d84a1b7 100644
 +    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_binlog_archive_replica), CMD_LINE(OPT_ARG),
 +    DEFAULT(false));
 +
++static Sys_var_ulong Sys_binlog_archive_replica_flush_period(
++    "binlog_archive_replica_flush_period",
++    "The time period for binlog archive replica thread flushing incremental "
++    "binlogs from the source binlog object storage",
++    GLOBAL_VAR(opt_binlog_archive_replica_flush_period), CMD_LINE(REQUIRED_ARG),
++    VALID_RANGE(1, ULONG_MAX), DEFAULT(1), BLOCK_SIZE(1));
++
 +static Sys_var_charptr Sys_binlog_archive_replica_source_log_file(
 +    "binlog_archive_replica_source_log_file",
-+    "The start source binlog file for snapshot archive replica",
++    "The start source binlog file for binlog archive replica",
 +    GLOBAL_VAR(opt_binlog_archive_replica_source_log_file),
 +    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT(nullptr));
 +

--- a/patches/mysql-server-8.0.35.patch
+++ b/patches/mysql-server-8.0.35.patch
@@ -2751,10 +2751,10 @@ index e010b378799..a6f94f8f194 100644
  ################################################################################
  # DO NOT add messages for the error-log to this file;
 diff --git a/share/messages_to_error_log.txt b/share/messages_to_error_log.txt
-index cdef214ae5f..7d4b4479f98 100644
+index cdef214ae5f..2f1f0545876 100644
 --- a/share/messages_to_error_log.txt
 +++ b/share/messages_to_error_log.txt
-@@ -12293,6 +12293,450 @@ ER_WARN_DEPRECATED_OR_BLOCKED_CIPHER
+@@ -12293,6 +12293,459 @@ ER_WARN_DEPRECATED_OR_BLOCKED_CIPHER
  # End of 8.0 error messages intended to be written to the server error log.
  #
  
@@ -3168,6 +3168,15 @@ index cdef214ae5f..7d4b4479f98 100644
 +ER_BINLOG_ARCHIVE_PURGE_LOG
 +  eng "Binlog archive: purge persistent binlog %s"
 +
++ER_BINLOG_ARCHIVE_REPLICA
++  eng "Binlog archive replica: %s."
++
++ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER
++  eng "Binlog archive replica replay worker: %s."
++
++ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER
++  eng "Binlog archive replica io worker %d: %s."
++
 +ER_CONSISTENT_SNAPSHOT_LOG
 +   eng "Snapshot archive: %s"
 +
@@ -3206,7 +3215,7 @@ index cdef214ae5f..7d4b4479f98 100644
  # Error numbers 50000 to 51999 are reserved. Please do not use them for
  # other error messages.
 diff --git a/sql/CMakeLists.txt b/sql/CMakeLists.txt
-index 4691f507e46..d391e5532f9 100644
+index 4691f507e46..6e7c49bfbbe 100644
 --- a/sql/CMakeLists.txt
 +++ b/sql/CMakeLists.txt
 @@ -633,7 +633,25 @@ SET(SQL_SHARED_SOURCES
@@ -3235,16 +3244,17 @@ index 4691f507e46..d391e5532f9 100644
  
  IF(BUILD_IS_SINGLE_CONFIG)
    GET_PROPERTY(CWD_DEFINITIONS DIRECTORY PROPERTY COMPILE_DEFINITIONS)
-@@ -1003,6 +1021,8 @@ SET(BINLOG_SOURCE
+@@ -1003,6 +1021,9 @@ SET(BINLOG_SOURCE
    binlog/monitoring/context.cc
    binlog/decompressing_event_object_istream.cc
    binlog.cc
 +  binlog_archive.cc
++  binlog_archive_replica.cc
 +  binlog_archive_command.cc
    binlog_istream.cc
    binlog_ostream.cc
    binlog_reader.cc
-@@ -1011,6 +1031,10 @@ SET(BINLOG_SOURCE
+@@ -1011,6 +1032,10 @@ SET(BINLOG_SOURCE
    changestreams/misc/column_filters/column_filter_inbound_func_indexes.cc
    changestreams/misc/column_filters/column_filter_inbound_gipk.cc
    changestreams/misc/column_filters/column_filter_outbound_func_indexes.cc
@@ -3255,7 +3265,7 @@ index 4691f507e46..d391e5532f9 100644
    log_event.cc
    rpl_commit_stage_manager.cc
    rpl_filter.cc
-@@ -1089,6 +1113,16 @@ SET (RPL_REPLICA_SRCS
+@@ -1089,6 +1114,16 @@ SET (RPL_REPLICA_SRCS
    udf_service_impl.cc
    udf_service_util.cc
    )
@@ -4674,10 +4684,10 @@ index c288026b810..22d6c7b9d24 100644
  
  #endif /* _log_event_h */
 diff --git a/sql/mysqld.cc b/sql/mysqld.cc
-index 3f94e768956..a7c2475e3da 100644
+index 3f94e768956..17d146270c6 100644
 --- a/sql/mysqld.cc
 +++ b/sql/mysqld.cc
-@@ -774,15 +774,18 @@ MySQL clients support the protocol:
+@@ -774,15 +774,19 @@ MySQL clients support the protocol:
  #include "sql/auth/auth_common.h"         // grant_init
  #include "sql/auth/sql_authentication.h"  // init_rsa_keys
  #include "sql/auth/sql_security_ctx.h"
@@ -4687,6 +4697,7 @@ index 3f94e768956..a7c2475e3da 100644
 +#include "sql/auto_thd.h"        // Auto_THD
 +#include "sql/binlog.h"          // mysql_bin_log
 +#include "sql/binlog_archive.h"  // start_binlog_archive
++#include "sql/binlog_archive_replica.h" // start_binlog_archive_replica
 +#include "sql/bootstrap.h"       // bootstrap
  #include "sql/check_stack.h"
  #include "sql/conn_handler/connection_acceptor.h"  // Connection_acceptor
@@ -4700,7 +4711,7 @@ index 3f94e768956..a7c2475e3da 100644
  #include "sql/dd/cache/dictionary_client.h"
  #include "sql/debug_sync.h"  // debug_sync_end
  #include "sql/derror.h"
-@@ -885,6 +888,10 @@ MySQL clients support the protocol:
+@@ -885,6 +889,10 @@ MySQL clients support the protocol:
  #include "typelib.h"
  #include "violite.h"
  
@@ -4711,7 +4722,7 @@ index 3f94e768956..a7c2475e3da 100644
  #ifdef WITH_PERFSCHEMA_STORAGE_ENGINE
  #include "storage/perfschema/pfs_server.h"
  #endif /* WITH_PERFSCHEMA_STORAGE_ENGINE */
-@@ -1221,6 +1228,9 @@ bool opt_no_monitor = false;
+@@ -1221,6 +1229,9 @@ bool opt_no_monitor = false;
  
  bool opt_no_dd_upgrade = false;
  long opt_upgrade_mode = UPGRADE_AUTO;
@@ -4721,7 +4732,7 @@ index 3f94e768956..a7c2475e3da 100644
  bool opt_initialize = false;
  bool opt_skip_replica_start = false;  ///< If set, slave is not autostarted
  bool opt_enable_named_pipe = false;
-@@ -1500,6 +1510,65 @@ char server_version[SERVER_VERSION_LENGTH];
+@@ -1500,6 +1511,68 @@ char server_version[SERVER_VERSION_LENGTH];
  const char *mysqld_unix_port;
  char *opt_mysql_tmpdir;
  
@@ -4744,6 +4755,9 @@ index 3f94e768956..a7c2475e3da 100644
 +ulong opt_binlog_archive_expire_seconds = 0;
 +ulonglong opt_binlog_archive_period = 0;
 +ulong opt_binlog_archive_parallel_workers = 0;
++bool opt_binlog_archive_replica = false;
++char *opt_binlog_archive_replica_source_log_file = nullptr;
++ulong opt_binlog_archive_replica_source_log_pos = 0;
 +char *opt_consistent_snapshot_archive_dir = nullptr;
 +bool opt_consistent_snapshot_persistent_on_objstore = false;
 +bool opt_initialize_use_objstore = false;
@@ -4758,15 +4772,15 @@ index 3f94e768956..a7c2475e3da 100644
 +char *opt_recovery_consistent_snapshot_tmpdir = nullptr;
 +bool opt_recovery_consistent_snapshot_only = false;
 +char *opt_recovery_consistent_snapshot_timestamp = nullptr;
-+bool opt_initialize_from_objstore = false;
-+char *opt_initialize_objstore_provider = nullptr;
-+char *opt_initialize_objstore_region = nullptr;
-+char *opt_initialize_objstore_endpoint = nullptr;
-+bool opt_initialize_objstore_use_https = false;
-+char *opt_initialize_objstore_bucket = nullptr;
-+char *opt_initialize_repo_objstore_id = nullptr;
-+char *opt_initialize_branch_objstore_id = nullptr;
-+bool opt_initialize_smartengine_objectstore_data = false;
++bool opt_initialize_from_source_objectstore = false;
++char *opt_source_objectstore_provider = nullptr;
++char *opt_source_objectstore_region = nullptr;
++char *opt_source_objectstore_endpoint = nullptr;
++bool opt_source_objectstore_use_https = false;
++char *opt_source_objectstore_bucket = nullptr;
++char *opt_source_objectstore_repo_id = nullptr;
++char *opt_source_objectstore_branch_id = nullptr;
++bool opt_source_objectstore_smartengine_data = false;
 +bool opt_serverless = true;
 +/**
 +  TODO(cnut): how to validate the relationship between different variables of
@@ -4787,7 +4801,7 @@ index 3f94e768956..a7c2475e3da 100644
  char *opt_authentication_policy;
  std::vector<std::string> authentication_policy_list;
  /*
-@@ -2362,6 +2431,11 @@ static void close_connections(void) {
+@@ -2362,6 +2435,12 @@ static void close_connections(void) {
    Call_close_conn call_close_conn(true);
    thd_manager->do_for_all_thd(&call_close_conn);
  
@@ -4795,20 +4809,22 @@ index 3f94e768956..a7c2475e3da 100644
 +  // smartengine plugin and clone plugin.
 +  stop_consistent_archive();
 +  stop_binlog_archive();
++  stop_binlog_archive_replica();
 +
    (void)RUN_HOOK(server_state, after_server_shutdown, (nullptr));
  
    /*
-@@ -2493,6 +2567,8 @@ void clean_up_mysqld_mutexes() { clean_up_mutexes(); }
+@@ -2493,6 +2572,9 @@ void clean_up_mysqld_mutexes() { clean_up_mutexes(); }
  static void mysqld_exit(int exit_code) {
    assert((exit_code >= MYSQLD_SUCCESS_EXIT && exit_code <= MYSQLD_ABORT_EXIT) ||
           exit_code == MYSQLD_RESTART_EXIT);
 +  (Binlog_archive::get_instance())->deinit_pthread_object();
 +  (Consistent_archive::get_instance())->deinit_pthread_object();
++  (Binlog_archive_replica::get_instance())->deinit_pthread_object();
    mysql_audit_finalize();
    Srv_session::module_deinit();
    delete_optimizer_cost_module();
-@@ -4272,6 +4348,10 @@ SHOW_VAR com_status_vars[] = {
+@@ -4272,6 +4354,10 @@ SHOW_VAR com_status_vars[] = {
       (char *)offsetof(System_status_var,
                        com_stat[(uint)SQLCOM_SHOW_BINLOG_EVENTS]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4819,7 +4835,7 @@ index 3f94e768956..a7c2475e3da 100644
      {"show_binlogs",
       (char *)offsetof(System_status_var, com_stat[(uint)SQLCOM_SHOW_BINLOGS]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
-@@ -4443,6 +4523,14 @@ SHOW_VAR com_status_vars[] = {
+@@ -4443,6 +4529,14 @@ SHOW_VAR com_status_vars[] = {
       (char *)offsetof(System_status_var,
                        com_stat[(uint)SQLCOM_STOP_GROUP_REPLICATION]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4834,7 +4850,7 @@ index 3f94e768956..a7c2475e3da 100644
      {"stmt_execute", (char *)offsetof(System_status_var, com_stmt_execute),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
      {"stmt_close", (char *)offsetof(System_status_var, com_stmt_close),
-@@ -4498,6 +4586,16 @@ SHOW_VAR com_status_vars[] = {
+@@ -4498,6 +4592,16 @@ SHOW_VAR com_status_vars[] = {
      {"xa_start",
       (char *)offsetof(System_status_var, com_stat[(uint)SQLCOM_XA_START]),
       SHOW_LONG_STATUS, SHOW_SCOPE_ALL},
@@ -4851,17 +4867,18 @@ index 3f94e768956..a7c2475e3da 100644
      {NullS, NullS, SHOW_LONG, SHOW_SCOPE_ALL}};
  
  LEX_CSTRING sql_statement_names[(uint)SQLCOM_END + 1];
-@@ -4817,6 +4915,9 @@ int init_common_variables() {
+@@ -4817,6 +4921,10 @@ int init_common_variables() {
    */
    mysql_bin_log.init_pthread_objects();
  
 +  (Binlog_archive::get_instance())->init_pthread_object();
 +  (Consistent_archive::get_instance())->init_pthread_object();
++  (Binlog_archive_replica::get_instance())->init_pthread_object();
 +
    /* TODO: remove this when my_time_t is 64 bit compatible */
    if (!is_time_t_valid_for_timestamp(server_start_time)) {
      LogErr(ERROR_LEVEL, ER_UNSUPPORTED_DATE);
-@@ -4859,6 +4960,12 @@ int init_common_variables() {
+@@ -4859,6 +4967,12 @@ int init_common_variables() {
    default_storage_engine = "InnoDB";
    default_tmp_storage_engine = default_storage_engine;
  
@@ -4874,7 +4891,7 @@ index 3f94e768956..a7c2475e3da 100644
    /*
      Add server status variables to the dynamic list of
      status variables that is shown by SHOW STATUS.
-@@ -6286,6 +6393,14 @@ static int init_server_components() {
+@@ -6286,6 +6400,14 @@ static int init_server_components() {
        opt_bin_logname = my_strdup(key_memory_opt_bin_logname, buf, MYF(0));
      }
  
@@ -4889,7 +4906,7 @@ index 3f94e768956..a7c2475e3da 100644
      /*
        Skip opening the index file if we start with --help. This is necessary
        to avoid creating the file in an otherwise empty datadir, which will
-@@ -6503,6 +6618,33 @@ static int init_server_components() {
+@@ -6503,6 +6625,33 @@ static int init_server_components() {
        LogErr(ERROR_LEVEL, ER_CANT_INITIALIZE_BUILTIN_PLUGINS);
      unireg_abort(1);
    }
@@ -4909,7 +4926,7 @@ index 3f94e768956..a7c2475e3da 100644
 +    }
 +
 +    // Consistent recovery smartengine sst when clone instance.
-+    if (unlikely(opt_initialize) && opt_initialize_from_objstore &&
++    if (unlikely(opt_initialize) && opt_initialize_from_source_objectstore &&
 +        consistent_recovery.recovery_smartengine_objectstore_data()) {
 +      LogErr(ERROR_LEVEL, ER_CONSISTENT_SNAPSHOT_LOG,
 +             "Failed to recovery smartengine sst from object storage");
@@ -4917,13 +4934,13 @@ index 3f94e768956..a7c2475e3da 100644
 +    }
 +    // Consistent recovery finish.
 +    consistent_recovery.recovery_consistent_snapshot_finish();
-+    if(unlikely(opt_initialize) && opt_initialize_from_objstore) 
++    if(unlikely(opt_initialize) && opt_initialize_from_source_objectstore) 
 +      unireg_abort(MYSQLD_SUCCESS_EXIT);
 +  }
  
    /*
      Needs to be done before dd::init() which runs DDL commands (for real)
-@@ -6785,6 +6927,27 @@ static int init_server_components() {
+@@ -6785,6 +6934,27 @@ static int init_server_components() {
      unireg_abort(1);
    }
  
@@ -4951,7 +4968,7 @@ index 3f94e768956..a7c2475e3da 100644
    if (opt_initialize) log_output_options = LOG_FILE;
  
    /*
-@@ -6818,6 +6981,20 @@ static int init_server_components() {
+@@ -6818,6 +6988,20 @@ static int init_server_components() {
    /*
      Set the default storage engines
    */
@@ -4972,7 +4989,7 @@ index 3f94e768956..a7c2475e3da 100644
    if (initialize_storage_engine(default_storage_engine, "",
                                  &global_system_variables.table_plugin))
      unireg_abort(MYSQLD_ABORT_EXIT);
-@@ -6890,7 +7067,22 @@ static int init_server_components() {
+@@ -6890,7 +7074,22 @@ static int init_server_components() {
      unireg_abort(MYSQLD_ABORT_EXIT);
    }
  
@@ -4996,7 +5013,7 @@ index 3f94e768956..a7c2475e3da 100644
      /*
        Configures what object is used by the current log to store processed
        gtid(s). This is necessary in the MYSQL_BIN_LOG::MYSQL_BIN_LOG to
-@@ -7531,6 +7723,11 @@ int mysqld_main(int argc, char **argv)
+@@ -7531,6 +7730,11 @@ int mysqld_main(int argc, char **argv)
    */
    init_server_psi_keys();
  
@@ -5008,7 +5025,7 @@ index 3f94e768956..a7c2475e3da 100644
    /*
      Now that some instrumentation is in place,
      recreate objects which were initialised early,
-@@ -7818,6 +8015,16 @@ int mysqld_main(int argc, char **argv)
+@@ -7818,6 +8022,16 @@ int mysqld_main(int argc, char **argv)
      unireg_abort(exit_state);
    }
  
@@ -5025,7 +5042,7 @@ index 3f94e768956..a7c2475e3da 100644
    /*
     We have enough space for fiddling with the argv, continue
    */
-@@ -7830,6 +8037,63 @@ int mysqld_main(int argc, char **argv)
+@@ -7830,6 +8044,63 @@ int mysqld_main(int argc, char **argv)
      unireg_abort(MYSQLD_ABORT_EXIT); /* purecov: inspected */
    }
  
@@ -5058,7 +5075,7 @@ index 3f94e768956..a7c2475e3da 100644
 +  // Binlog recovery will be done after bin-log and bin-log-index option is
 +  // ready.
 +  if (!is_help_or_validate_option() && opt_serverless &&
-+      (opt_recovery_from_objstore || opt_initialize_from_objstore)) {
++      (opt_recovery_from_objstore || opt_initialize_from_source_objectstore)) {
 +    Consistent_snapshot_recovery_status recovery_status = {};
 +    if (consistent_recovery.read_consistent_snapshot_recovery_status(
 +            recovery_status) == 0) {
@@ -5073,12 +5090,12 @@ index 3f94e768956..a7c2475e3da 100644
 +      strmake(mysql_path, mysql_real_data_home, sizeof(mysql_path) - 1);
 +      convert_dirname(mysql_path, mysql_path, NullS);
 +      strcat(mysql_path, "mysql");
-+      if ((opt_initialize && opt_initialize_from_objstore) ||
++      if ((opt_initialize && opt_initialize_from_source_objectstore) ||
 +          (!opt_initialize && opt_recovery_from_objstore &&
 +           !my_stat(mysql_path, &stat, MYF(0)))) {
 +        // 1. If $datadir/mysql not exists, we need to recover from object
 +        // store.
-+        // 2. If opt_initialize_from_objstore is set, we need to recover from
++        // 2. If opt_initialize_from_source_objectstore is set, we need to recover from
 +        // object store.
 +        if (consistent_recovery.recovery_consistent_snapshot(0))
 +          unireg_abort(MYSQLD_ABORT_EXIT); /* purecov: inspected */
@@ -5089,7 +5106,7 @@ index 3f94e768956..a7c2475e3da 100644
    /*
     The subsequent calls may take a long time : e.g. innodb log read.
     Thus set the long running service control manager timeout
-@@ -7879,6 +8143,16 @@ int mysqld_main(int argc, char **argv)
+@@ -7879,6 +8150,16 @@ int mysqld_main(int argc, char **argv)
      if (gtid_state->read_gtid_executed_from_table() == -1) unireg_abort(1);
    }
  
@@ -5106,7 +5123,7 @@ index 3f94e768956..a7c2475e3da 100644
    if (opt_bin_log) {
      /*
        Initialize GLOBAL.GTID_EXECUTED and GLOBAL.GTID_PURGED from
-@@ -7998,6 +8272,14 @@ int mysqld_main(int argc, char **argv)
+@@ -7998,6 +8279,14 @@ int mysqld_main(int argc, char **argv)
      (void)RUN_HOOK(server_state, after_engine_recovery, (nullptr));
    }
  
@@ -5121,7 +5138,7 @@ index 3f94e768956..a7c2475e3da 100644
    if (init_ssl_communication()) unireg_abort(MYSQLD_ABORT_EXIT);
    if (network_init()) unireg_abort(MYSQLD_ABORT_EXIT);
  
-@@ -8133,8 +8415,22 @@ int mysqld_main(int argc, char **argv)
+@@ -8133,8 +8422,22 @@ int mysqld_main(int argc, char **argv)
  
    initialize_information_schema_acl();
  
@@ -5144,7 +5161,21 @@ index 3f94e768956..a7c2475e3da 100644
    if (Events::init(opt_noacl || opt_initialize))
      unireg_abort(MYSQLD_ABORT_EXIT);
  
-@@ -9267,6 +9563,12 @@ struct my_option my_long_options[] = {
+@@ -8158,6 +8461,13 @@ int mysqld_main(int argc, char **argv)
+     return 1;
+   }
+ 
++  if (!opt_initialize) {
++    // start binlog archive replica.
++    if (start_binlog_archive_replica()) {
++      unireg_abort(MYSQLD_ABORT_EXIT);
++    }
++  }
++
+   /*
+     Invoke the bootstrap thread, if required.
+   */
+@@ -9267,6 +9577,12 @@ struct my_option my_long_options[] = {
       &opt_upgrade_mode, &opt_upgrade_mode, &upgrade_mode_typelib, GET_ENUM,
       REQUIRED_ARG, UPGRADE_AUTO, 0, 0, nullptr, 0, nullptr},
  
@@ -5157,7 +5188,7 @@ index 3f94e768956..a7c2475e3da 100644
      {nullptr, 0, nullptr, nullptr, nullptr, nullptr, GET_NO_ARG, NO_ARG, 0, 0,
       0, nullptr, 0, nullptr}};
  
-@@ -11131,6 +11433,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
+@@ -11131,6 +11447,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
  #ifndef _WIN32
    if (mysqld_chroot) set_root(mysqld_chroot);
  #endif
@@ -5165,7 +5196,7 @@ index 3f94e768956..a7c2475e3da 100644
    if (fix_paths()) return 1;
  
    /*
-@@ -11184,6 +11487,11 @@ static void set_server_version(void) {
+@@ -11184,6 +11501,11 @@ static void set_server_version(void) {
  #ifndef NDEBUG
    if (!strstr(MYSQL_SERVER_SUFFIX_STR, "-debug"))
      end = my_stpcpy(end, "-debug");
@@ -5177,7 +5208,7 @@ index 3f94e768956..a7c2475e3da 100644
  #endif
  #ifdef HAVE_VALGRIND
    if (SERVER_VERSION_LENGTH - (end - server_version) >
-@@ -11795,6 +12103,13 @@ PSI_mutex_key key_monitor_info_run_lock;
+@@ -11795,6 +12117,13 @@ PSI_mutex_key key_monitor_info_run_lock;
  PSI_mutex_key key_LOCK_delegate_connection_mutex;
  PSI_mutex_key key_LOCK_group_replication_connection_mutex;
  
@@ -5191,7 +5222,7 @@ index 3f94e768956..a7c2475e3da 100644
  /* clang-format off */
  static PSI_mutex_info all_server_mutexes[]=
  {
-@@ -11861,6 +12176,12 @@ static PSI_mutex_info all_server_mutexes[]=
+@@ -11861,6 +12190,12 @@ static PSI_mutex_info all_server_mutexes[]=
    { &key_mutex_slave_parallel_pend_jobs, "Relay_log_info::pending_jobs_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_mutex_slave_parallel_worker_count, "Relay_log_info::exit_count_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_mutex_slave_parallel_worker, "Worker_info::jobs_lock", 0, 0, PSI_DOCUMENT_ME},
@@ -5204,7 +5235,7 @@ index 3f94e768956..a7c2475e3da 100644
    { &key_TABLE_SHARE_LOCK_ha_data, "TABLE_SHARE::LOCK_ha_data", 0, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_error_messages, "LOCK_error_messages", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_log_throttle_qni, "LOCK_log_throttle_qni", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
-@@ -11887,7 +12208,7 @@ static PSI_mutex_info all_server_mutexes[]=
+@@ -11887,7 +12222,7 @@ static PSI_mutex_info all_server_mutexes[]=
    { &key_monitor_info_run_lock, "Source_IO_monitor::run_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_delegate_connection_mutex, "LOCK_delegate_connection_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_LOCK_group_replication_connection_mutex, "LOCK_group_replication_connection_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
@@ -5213,7 +5244,7 @@ index 3f94e768956..a7c2475e3da 100644
    { &key_LOCK_global_conn_mem_limit, "LOCK_global_conn_mem_limit", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME}
  };
  /* clang-format on */
-@@ -11906,6 +12227,14 @@ PSI_rwlock_key key_rwlock_Binlog_transmit_delegate_lock;
+@@ -11906,6 +12241,14 @@ PSI_rwlock_key key_rwlock_Binlog_transmit_delegate_lock;
  PSI_rwlock_key key_rwlock_Binlog_relay_IO_delegate_lock;
  PSI_rwlock_key key_rwlock_resource_group_mgr_map_lock;
  
@@ -5228,7 +5259,7 @@ index 3f94e768956..a7c2475e3da 100644
  /* clang-format off */
  static PSI_rwlock_info all_server_rwlocks[]=
  {
-@@ -11922,6 +12251,13 @@ static PSI_rwlock_info all_server_rwlocks[]=
+@@ -11922,6 +12265,13 @@ static PSI_rwlock_info all_server_rwlocks[]=
    { &key_rwlock_Trans_delegate_lock, "Trans_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_Server_state_delegate_lock, "Server_state_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_Binlog_storage_delegate_lock, "Binlog_storage_delegate::lock", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
@@ -5242,7 +5273,7 @@ index 3f94e768956..a7c2475e3da 100644
    { &key_rwlock_receiver_sid_lock, "gtid_retrieved", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_rpl_filter_lock, "rpl_filter_lock", 0, 0, PSI_DOCUMENT_ME},
    { &key_rwlock_channel_to_filter_lock, "channel_to_filter_lock", 0, 0, PSI_DOCUMENT_ME},
-@@ -11960,6 +12296,12 @@ PSI_cond_key key_cond_slave_worker_hash;
+@@ -11960,6 +12310,12 @@ PSI_cond_key key_cond_slave_worker_hash;
  PSI_cond_key key_monitor_info_run_cond;
  PSI_cond_key key_COND_delegate_connection_cond_var;
  PSI_cond_key key_COND_group_replication_connection_cond_var;
@@ -5255,7 +5286,7 @@ index 3f94e768956..a7c2475e3da 100644
  
  /* clang-format off */
  static PSI_cond_info all_server_conds[]=
-@@ -11997,6 +12339,12 @@ static PSI_cond_info all_server_conds[]=
+@@ -11997,6 +12353,12 @@ static PSI_cond_info all_server_conds[]=
    { &key_cond_slave_parallel_pend_jobs, "Relay_log_info::pending_jobs_cond", 0, 0, PSI_DOCUMENT_ME},
    { &key_cond_slave_parallel_worker, "Worker_info::jobs_cond", 0, 0, PSI_DOCUMENT_ME},
    { &key_cond_mta_gaq, "Relay_log_info::mta_gaq_cond", 0, 0, PSI_DOCUMENT_ME},
@@ -5269,7 +5300,7 @@ index 3f94e768956..a7c2475e3da 100644
    { &key_COND_compress_gtid_table, "COND_compress_gtid_table", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
    { &key_commit_order_manager_cond, "Commit_order_manager::m_workers.cond", 0, 0, PSI_DOCUMENT_ME},
 diff --git a/sql/mysqld.h b/sql/mysqld.h
-index 8b5a842b54b..9f53718f532 100644
+index 8b5a842b54b..32ac050fe84 100644
 --- a/sql/mysqld.h
 +++ b/sql/mysqld.h
 @@ -180,6 +180,9 @@ extern MYSQL_PLUGIN_IMPORT std::atomic<int32>
@@ -5305,7 +5336,7 @@ index 8b5a842b54b..9f53718f532 100644
  #endif /* HAVE_PSI_INTERFACE */
  
  /*
-@@ -698,6 +717,56 @@ extern MYSQL_PLUGIN_IMPORT char pidfile_name[];
+@@ -698,6 +717,59 @@ extern MYSQL_PLUGIN_IMPORT char pidfile_name[];
  
  #define mysql_tmpdir (my_tmpdir(&mysql_tmpdir_list))
  
@@ -5326,6 +5357,9 @@ index 8b5a842b54b..9f53718f532 100644
 +extern ulong opt_binlog_archive_expire_seconds;
 +extern ulonglong opt_binlog_archive_period;
 +extern ulong opt_binlog_archive_parallel_workers;
++extern bool opt_binlog_archive_replica;
++extern char *opt_binlog_archive_replica_source_log_file;
++extern ulong opt_binlog_archive_replica_source_log_pos;
 +extern char *opt_consistent_snapshot_archive_dir;
 +extern bool opt_consistent_snapshot_persistent_on_objstore;
 +extern bool opt_initialize_use_objstore;
@@ -5340,15 +5374,15 @@ index 8b5a842b54b..9f53718f532 100644
 +extern char *opt_recovery_consistent_snapshot_tmpdir;
 +extern bool opt_recovery_consistent_snapshot_only;
 +extern char *opt_recovery_consistent_snapshot_timestamp;
-+extern bool opt_initialize_from_objstore;
-+extern char *opt_initialize_objstore_provider;
-+extern char *opt_initialize_objstore_region;
-+extern char *opt_initialize_objstore_endpoint;
-+extern bool opt_initialize_objstore_use_https;
-+extern char *opt_initialize_objstore_bucket;
-+extern char *opt_initialize_repo_objstore_id;
-+extern char *opt_initialize_branch_objstore_id;
-+extern bool opt_initialize_smartengine_objectstore_data;
++extern bool opt_initialize_from_source_objectstore;
++extern char *opt_source_objectstore_provider;
++extern char *opt_source_objectstore_region;
++extern char *opt_source_objectstore_endpoint;
++extern bool opt_source_objectstore_use_https;
++extern char *opt_source_objectstore_bucket;
++extern char *opt_source_objectstore_repo_id;
++extern char *opt_source_objectstore_branch_id;
++extern bool opt_source_objectstore_smartengine_data;
 +
 +extern MYSQL_PLUGIN_IMPORT bool opt_serverless;
 +extern MYSQL_PLUGIN_IMPORT bool opt_table_on_objstore;
@@ -6647,7 +6681,7 @@ index b11348b5b48..346978f5c55 100644
       Forward iterators to initiate traversing of a map.
  
 diff --git a/sql/rpl_replica.cc b/sql/rpl_replica.cc
-index 57dfb700ea5..c2817e34ad5 100644
+index 57dfb700ea5..8361ce91d56 100644
 --- a/sql/rpl_replica.cc
 +++ b/sql/rpl_replica.cc
 @@ -650,6 +650,21 @@ bool start_slave(THD *thd) {
@@ -6882,7 +6916,21 @@ index 57dfb700ea5..c2817e34ad5 100644
    // Value-initialization, to avoid compiler warnings on push_back.
    Slave_job_group job_worker = Slave_job_group();
  
-@@ -6510,6 +6649,10 @@ bool mta_checkpoint_routine(Relay_log_info *rli, bool force) {
+@@ -6343,6 +6482,13 @@ bool mts_recovery_groups(Relay_log_info *rli) {
+ 
+         if (ev->get_type_code() == binary_log::ROTATE_EVENT ||
+             ev->get_type_code() == binary_log::FORMAT_DESCRIPTION_EVENT ||
++#ifdef WESQL_CLUSTER
++            ev->get_type_code() ==
++                binary_log::PREVIOUS_CONSENSUS_INDEX_LOG_EVENT ||
++            ev->get_type_code() == binary_log::CONSENSUS_LOG_EVENT ||
++            ev->get_type_code() == binary_log::CONSENSUS_CLUSTER_INFO_EVENT ||
++            ev->get_type_code() == binary_log::CONSENSUS_EMPTY_EVENT ||
++#endif
+             ev->get_type_code() == binary_log::PREVIOUS_GTIDS_LOG_EVENT) {
+           delete ev;
+           ev = nullptr;
+@@ -6510,6 +6656,10 @@ bool mta_checkpoint_routine(Relay_log_info *rli, bool force) {
    if (rli->gaq->lwm.group_relay_log_name[0] != 0)
      rli->set_group_relay_log_name(rli->gaq->lwm.group_relay_log_name);
  
@@ -6893,7 +6941,7 @@ index 57dfb700ea5..c2817e34ad5 100644
    /*
       todo: uncomment notifies when UNTIL will be supported
  
-@@ -7090,6 +7233,18 @@ extern "C" void *handle_slave_sql(void *arg) {
+@@ -7090,6 +7240,18 @@ extern "C" void *handle_slave_sql(void *arg) {
        goto err;
      }
  
@@ -6912,7 +6960,7 @@ index 57dfb700ea5..c2817e34ad5 100644
      /* MTS: starting the worker pool */
      if (slave_start_workers(rli, rli->opt_replica_parallel_workers,
                              &mts_inited) != 0) {
-@@ -7159,6 +7314,15 @@ extern "C" void *handle_slave_sql(void *arg) {
+@@ -7159,6 +7321,15 @@ extern "C" void *handle_slave_sql(void *arg) {
      rli->trans_retries = 0;  // start from "no error"
      DBUG_PRINT("info", ("rli->trans_retries: %lu", rli->trans_retries));
  
@@ -6928,7 +6976,7 @@ index 57dfb700ea5..c2817e34ad5 100644
      if (applier_reader.open(&errmsg)) {
        rli->report(ERROR_LEVEL, ER_REPLICA_FATAL_ERROR, "%s", errmsg);
        goto err;
-@@ -7261,8 +7425,23 @@ extern "C" void *handle_slave_sql(void *arg) {
+@@ -7261,8 +7432,23 @@ extern "C" void *handle_slave_sql(void *arg) {
          saved_skip = 0;
        }
  
@@ -6952,7 +7000,7 @@ index 57dfb700ea5..c2817e34ad5 100644
        ev = applier_reader.read_next_event();
        mysql_mutex_unlock(&rli->data_lock);
  
-@@ -7346,6 +7525,22 @@ extern "C" void *handle_slave_sql(void *arg) {
+@@ -7346,6 +7532,22 @@ extern "C" void *handle_slave_sql(void *arg) {
      thd->reset_query();
      thd->reset_db(NULL_CSTR);
  
@@ -6975,7 +7023,427 @@ index 57dfb700ea5..c2817e34ad5 100644
      /*
        Pause the SQL thread and wait for 'continue_to_stop_sql_thread'
        signal to continue to shutdown the SQL thread.
-@@ -8638,6 +8833,14 @@ int flush_relay_logs(Master_info *mi, THD *thd) {
+@@ -8247,6 +8449,419 @@ end:
+   return res;
+ }
+ 
++/**
++ * @brief Store an event from the object store into the relay log.
++ *
++ * @param mi
++ * @param buf
++ * @param event_len
++ * @param do_flush_mi
++ * @param event_pos Mark that this event with "event_pos=0", so the slave should
++ not increment master's binlog position (mi->master_log_pos)
++ * @return QUEUE_EVENT_RESULT
++ */
++QUEUE_EVENT_RESULT queue_event_from_objstore(Master_info *mi, const char *buf,
++                                             ulong event_len,
++                                             bool do_flush_mi) {
++  QUEUE_EVENT_RESULT res = QUEUE_EVENT_OK;
++  ulong inc_pos = 0;
++  Relay_log_info *rli = mi->rli;
++  mysql_mutex_t *log_lock = rli->relay_log.get_log_lock();
++  ulong s_id;
++  int lock_count = 0;
++
++  enum_binlog_checksum_alg checksum_alg =
++      mi->checksum_alg_before_fd != binary_log::BINLOG_CHECKSUM_ALG_UNDEF
++          ? mi->checksum_alg_before_fd
++          : mi->rli->relay_log.relay_log_checksum_alg;
++
++  const char *save_buf =
++      nullptr;  // needed for checksumming the fake Rotate event
++  char rot_buf[LOG_EVENT_HEADER_LEN + Binary_log_event::ROTATE_HEADER_LEN +
++               FN_REFLEN];
++  Gtid gtid = {0, 0};
++  ulonglong immediate_commit_timestamp = 0;
++  ulonglong original_commit_timestamp = 0;
++  bool info_error{false};
++  binary_log::Log_event_basic_info log_event_info;
++  ulonglong compressed_transaction_bytes = 0;
++  ulonglong uncompressed_transaction_bytes = 0;
++  auto compression_type = binary_log::transaction::compression::type::NONE;
++  Log_event_type event_type = (Log_event_type)buf[EVENT_TYPE_OFFSET];
++
++  assert(checksum_alg == binary_log::BINLOG_CHECKSUM_ALG_OFF ||
++         checksum_alg == binary_log::BINLOG_CHECKSUM_ALG_UNDEF ||
++         checksum_alg == binary_log::BINLOG_CHECKSUM_ALG_CRC32);
++
++  DBUG_TRACE;
++
++  /*
++    Pause the binlog archive replica relay thread execution and wait for
++    'continue_queuing_event' signal to continue IO thread execution.
++  */
++  DBUG_SIGNAL_WAIT_FOR(current_thd, "pause_on_queuing_event_from_objstore",
++                       "reached_pause_on_queue_event_from_objstore",
++                       "continue_queuing_event_from_objstore");
++
++  if (event_type == binary_log::FORMAT_DESCRIPTION_EVENT) {
++    checksum_alg = Log_event_footer::get_checksum_alg(buf, event_len);
++  }
++
++  assert(mi->rli->relay_log.relay_log_checksum_alg !=
++         binary_log::BINLOG_CHECKSUM_ALG_UNDEF);
++
++  binary_log_debug::debug_checksum_test =
++      DBUG_EVALUATE_IF("simulate_checksum_test_failure", true, false);
++  if (Log_event_footer::event_checksum_test(
++          const_cast<uchar *>(pointer_cast<const uchar *>(buf)), event_len,
++          checksum_alg)) {
++    mi->report(ERROR_LEVEL, ER_NETWORK_READ_EVENT_CHECKSUM_FAILURE, "%s",
++               ER_THD(current_thd, ER_NETWORK_READ_EVENT_CHECKSUM_FAILURE));
++    goto err;
++  }
++
++  /*
++    From now, and up to finishing queuing the event, no other thread is allowed
++    to write to the relay log, or to rotate it.
++  */
++  mysql_mutex_lock(log_lock);
++  assert(lock_count == 0);
++  lock_count = 1;
++
++  if (mi->get_mi_description_event() == nullptr) {
++    LogErr(ERROR_LEVEL, ER_RPL_REPLICA_QUEUE_EVENT_FAILED_INVALID_CONFIGURATION,
++           mi->get_channel());
++    goto err;
++  }
++
++  std::tie(info_error, log_event_info) = extract_log_event_basic_info(
++      buf, event_len, mi->get_mi_description_event());
++  if (info_error || mi->transaction_parser.feed_event(log_event_info, true)) {
++    LogErr(WARNING_LEVEL,
++           ER_RPL_REPLICA_IO_THREAD_DETECTED_UNEXPECTED_EVENT_SEQUENCE,
++           mi->get_master_log_name(), mi->get_master_log_pos());
++  }
++
++  switch (event_type) {
++    case binary_log::STOP_EVENT:
++      do_flush_mi = false;
++      goto end;
++    case binary_log::ROTATE_EVENT: {
++      Format_description_log_event *fde = mi->get_mi_description_event();
++      enum_binlog_checksum_alg fde_checksum_alg = fde->footer()->checksum_alg;
++      if (fde_checksum_alg != checksum_alg)
++        fde->footer()->checksum_alg = checksum_alg;
++      Rotate_log_event rev(buf, fde);
++      fde->footer()->checksum_alg = fde_checksum_alg;
++
++      if (unlikely(process_io_rotate(mi, &rev))) {
++        // This error will be reported later at handle_slave_io().
++        goto err;
++      }
++      /*
++         Checksum special cases for the fake Rotate (R_f) event caused by the
++         protocol of events generation and serialization in RL where Rotate of
++         master is queued right next to FD of slave. Since it's only FD that
++         carries the alg desc of FD_s has to apply to R_m. Two special rules
++         apply only to the first R_f which comes in before any FD_m. The 2nd R_f
++         should be compatible with the FD_s that must have taken over the last
++         seen FD_m's (A).
++
++         RSC_1: If OM \and fake Rotate \and slave is configured to
++                to compute checksum for its first FD event for RL
++                the fake Rotate gets checksummed here.
++      */
++      if (uint4korr(&buf[0]) == 0 &&
++          checksum_alg == binary_log::BINLOG_CHECKSUM_ALG_OFF &&
++          mi->rli->relay_log.relay_log_checksum_alg !=
++              binary_log::BINLOG_CHECKSUM_ALG_OFF) {
++        ha_checksum rot_crc = checksum_crc32(0L, nullptr, 0);
++        event_len += BINLOG_CHECKSUM_LEN;
++        memcpy(rot_buf, buf, event_len - BINLOG_CHECKSUM_LEN);
++        int4store(&rot_buf[EVENT_LEN_OFFSET],
++                  uint4korr(rot_buf + EVENT_LEN_OFFSET) + BINLOG_CHECKSUM_LEN);
++        rot_crc = checksum_crc32(rot_crc, (const uchar *)rot_buf,
++                                 event_len - BINLOG_CHECKSUM_LEN);
++        int4store(&rot_buf[event_len - BINLOG_CHECKSUM_LEN], rot_crc);
++        assert(event_len == uint4korr(&rot_buf[EVENT_LEN_OFFSET]));
++        assert(mi->get_mi_description_event()->common_footer->checksum_alg ==
++               mi->rli->relay_log.relay_log_checksum_alg);
++        /* the first one */
++        assert(mi->checksum_alg_before_fd !=
++               binary_log::BINLOG_CHECKSUM_ALG_UNDEF);
++        save_buf = buf;
++        buf = rot_buf;
++      } else
++          /*
++            RSC_2: If NM \and fake Rotate \and slave does not compute checksum
++            the fake Rotate's checksum is stripped off before relay-logging.
++          */
++          if (uint4korr(&buf[0]) == 0 &&
++              checksum_alg != binary_log::BINLOG_CHECKSUM_ALG_OFF &&
++              mi->rli->relay_log.relay_log_checksum_alg ==
++                  binary_log::BINLOG_CHECKSUM_ALG_OFF) {
++        event_len -= BINLOG_CHECKSUM_LEN;
++        memcpy(rot_buf, buf, event_len);
++        int4store(&rot_buf[EVENT_LEN_OFFSET],
++                  uint4korr(rot_buf + EVENT_LEN_OFFSET) - BINLOG_CHECKSUM_LEN);
++        assert(event_len == uint4korr(&rot_buf[EVENT_LEN_OFFSET]));
++        assert(mi->get_mi_description_event()->common_footer->checksum_alg ==
++               mi->rli->relay_log.relay_log_checksum_alg);
++        /* the first one */
++        assert(mi->checksum_alg_before_fd !=
++               binary_log::BINLOG_CHECKSUM_ALG_UNDEF);
++        save_buf = buf;
++        buf = rot_buf;
++      }
++      inc_pos = 0;
++      break;
++    }
++    case binary_log::FORMAT_DESCRIPTION_EVENT: {
++      /*
++        Create an event, and save it (when we rotate the relay log, we will have
++        to write this event again).
++      */
++      mi->checksum_alg_before_fd = binary_log::BINLOG_CHECKSUM_ALG_UNDEF;
++      Format_description_log_event *new_fdle;
++      Log_event *ev = nullptr;
++      if (binlog_event_deserialize(reinterpret_cast<const unsigned char *>(buf),
++                                   event_len, mi->get_mi_description_event(),
++                                   true, &ev) != Binlog_read_error::SUCCESS) {
++        // This error will be reported later at handle_slave_io().
++        goto err;
++      }
++
++      new_fdle = dynamic_cast<Format_description_log_event *>(ev);
++      if (new_fdle->common_footer->checksum_alg ==
++          binary_log::BINLOG_CHECKSUM_ALG_UNDEF)
++        new_fdle->common_footer->checksum_alg =
++            binary_log::BINLOG_CHECKSUM_ALG_OFF;
++
++      mi->set_mi_description_event(new_fdle);
++
++      /* installing new value of checksum Alg for relay log */
++      mi->rli->relay_log.relay_log_checksum_alg =
++          new_fdle->common_footer->checksum_alg;
++
++      /*
++         Though this does some conversion to the slave's format, this will
++         preserve the master's binlog format version, and number of event types.
++      */
++      /*
++         If the event was not requested by the slave (the slave did not ask for
++         it), i.e. has end_log_pos=0, we do not increment
++         mi->get_master_log_pos()
++      */
++           /*
++         If the event was not requested by the slave (the slave did not ask for
++         it), i.e. has end_log_pos=0, we do not increment
++         mi->get_master_log_pos()
++      */
++      inc_pos = uint4korr(buf + LOG_POS_OFFSET) ? event_len : 0;
++    } break;
++
++    case binary_log::HEARTBEAT_LOG_EVENT: 
++    case binary_log::HEARTBEAT_LOG_EVENT_V2: {
++      assert(false);
++    } break;
++    case binary_log::PREVIOUS_GTIDS_LOG_EVENT: {
++      /*
++        This event does not have any meaning for the slave and
++        was just sent to show the slave the master is making
++        progress and avoid possible deadlocks.
++        So at this point, the event is replaced by a rotate
++        event what will make the slave to update what it knows
++        about the master's coordinates.
++      */
++      inc_pos = 0;
++      mysql_mutex_lock(&mi->data_lock);
++      mi->set_master_log_pos(mi->get_master_log_pos() + event_len);
++      mysql_mutex_unlock(&mi->data_lock);
++
++      if (write_rotate_to_master_pos_into_relay_log(
++              mi->info_thd, mi, true /* force_flush_mi_info */))
++        goto err;
++
++      do_flush_mi = false; /* write_rotate_... above flushed master info */
++      goto end;
++    } break;
++
++    case binary_log::TRANSACTION_PAYLOAD_EVENT: {
++      binary_log::Transaction_payload_event tpe(buf,
++                                                mi->get_mi_description_event());
++      compression_type = tpe.get_compression_type();
++      compressed_transaction_bytes = tpe.get_payload_size();
++      uncompressed_transaction_bytes = tpe.get_uncompressed_size();
++      auto gtid_monitoring_info = mi->get_gtid_monitoring_info();
++      gtid_monitoring_info->update(compression_type,
++                                   compressed_transaction_bytes,
++                                   uncompressed_transaction_bytes);
++      inc_pos = event_len;
++      break;
++    }
++
++    case binary_log::GTID_LOG_EVENT: {
++      /*
++        This can happen if the master uses GTID_MODE=OFF_PERMISSIVE, and
++        sends GTID events to the slave. A possible scenario is that user
++        does not follow the upgrade procedure for GTIDs, and creates a
++        topology like A->B->C, where A uses GTID_MODE=ON_PERMISSIVE, B
++        uses GTID_MODE=OFF_PERMISSIVE, and C uses GTID_MODE=OFF.  Each
++        connection is allowed, but the master A will generate GTID
++        transactions which will be sent through B to C.  Then C will hit
++        this error.
++      */
++      if (global_gtid_mode.get() == Gtid_mode::OFF) {
++        mi->report(
++            ERROR_LEVEL, ER_CANT_REPLICATE_GTID_WITH_GTID_MODE_OFF,
++            ER_THD(current_thd, ER_CANT_REPLICATE_GTID_WITH_GTID_MODE_OFF),
++            mi->get_master_log_name(), mi->get_master_log_pos());
++        goto err;
++      }
++      Gtid_log_event gtid_ev(buf, mi->get_mi_description_event());
++      if (!gtid_ev.is_valid()) goto err;
++      rli->get_sid_lock()->rdlock();
++      gtid.sidno = gtid_ev.get_sidno(rli->get_gtid_set()->get_sid_map());
++      rli->get_sid_lock()->unlock();
++      if (gtid.sidno < 0) goto err;
++      gtid.gno = gtid_ev.get_gno();
++      original_commit_timestamp = gtid_ev.original_commit_timestamp;
++      immediate_commit_timestamp = gtid_ev.immediate_commit_timestamp;
++      compressed_transaction_bytes = uncompressed_transaction_bytes =
++          gtid_ev.transaction_length - gtid_ev.get_event_length();
++
++      inc_pos = event_len;
++    } break;
++
++    case binary_log::ANONYMOUS_GTID_LOG_EVENT: {
++      if (mi->rli->m_assign_gtids_to_anonymous_transactions_info
++                   .get_type() == Assign_gtids_to_anonymous_transactions_info::
++                                      enum_type::AGAT_OFF) {
++        if (global_gtid_mode.get() == Gtid_mode::ON) {
++          mi->report(ERROR_LEVEL, ER_CANT_REPLICATE_ANONYMOUS_WITH_GTID_MODE_ON,
++                     ER_THD(current_thd,
++                            ER_CANT_REPLICATE_ANONYMOUS_WITH_GTID_MODE_ON),
++                     mi->get_master_log_name(), mi->get_master_log_pos());
++          goto err;
++        }
++      }
++      /*
++       save the original_commit_timestamp and the immediate_commit_timestamp to
++       be later used for monitoring
++      */
++      Gtid_log_event anon_gtid_ev(buf, mi->get_mi_description_event());
++      original_commit_timestamp = anon_gtid_ev.original_commit_timestamp;
++      immediate_commit_timestamp = anon_gtid_ev.immediate_commit_timestamp;
++      compressed_transaction_bytes = uncompressed_transaction_bytes =
++          anon_gtid_ev.transaction_length - anon_gtid_ev.get_event_length();
++    }
++      [[fallthrough]];
++    default:
++      inc_pos = event_len;
++      break;
++  }
++  s_id = uint4korr(buf + SERVER_ID_OFFSET);
++
++  /*
++    If server_id_bits option is set we need to mask out irrelevant bits
++    when checking server_id, but we still put the full unmasked server_id
++    into the Relay log so that it can be accessed when applying the event
++  */
++  s_id &= opt_server_id_mask;
++
++  if ((s_id == ::server_id && !mi->rli->replicate_same_server_id) ||
++      (mi->ignore_server_ids->dynamic_ids.size() > 0 &&
++       mi->shall_ignore_server_id(s_id) &&
++       /* everything is filtered out from non-master */
++       (s_id != mi->master_id ||
++        /* for the master meta information is necessary */
++        (event_type != binary_log::FORMAT_DESCRIPTION_EVENT &&
++         event_type != binary_log::ROTATE_EVENT)))) {
++    if (!(s_id == ::server_id && !mi->rli->replicate_same_server_id) ||
++        (event_type != binary_log::FORMAT_DESCRIPTION_EVENT &&
++         event_type != binary_log::ROTATE_EVENT &&
++         event_type != binary_log::STOP_EVENT)) {
++      rli->relay_log.lock_binlog_end_pos();
++      mi->set_master_log_pos(mi->get_master_log_pos() + inc_pos);
++      memcpy(rli->ign_master_log_name_end, mi->get_master_log_name(),
++             FN_REFLEN);
++      assert(rli->ign_master_log_name_end[0]);
++      rli->ign_master_log_pos_end = mi->get_master_log_pos();
++      // the slave SQL thread needs to re-check
++      rli->relay_log.update_binlog_end_pos(false /*need_lock*/);
++      rli->relay_log.unlock_binlog_end_pos();
++    }
++    DBUG_PRINT(
++        "info",
++        ("source_log_pos: %lu, event originating from %u server, ignored",
++         (ulong)mi->get_master_log_pos(), uint4korr(buf + SERVER_ID_OFFSET)));
++  } else {
++    bool is_error = false;
++    /* write the event to the relay log */
++    if (likely(rli->relay_log.write_buffer(buf, event_len, mi) == 0)) {
++      DBUG_SIGNAL_WAIT_FOR(
++          current_thd, "pause_on_queue_event_from_objstore_after_write_buffer",
++          "receiver_reached_pause_on_queue_event_from_objstore",
++          "receiver_continue_queuing_event_from_objstore");
++      mysql_mutex_lock(&mi->data_lock);
++      lock_count = 2;
++      mi->set_master_log_pos(mi->get_master_log_pos() + inc_pos);
++      DBUG_PRINT("info",
++                 ("source_log_pos: %lu", (ulong)mi->get_master_log_pos()));
++      if (event_type == binary_log::GTID_LOG_EVENT ||
++          event_type == binary_log::ANONYMOUS_GTID_LOG_EVENT) {
++        // set the timestamp for the start time of queueing this transaction
++        mi->started_queueing(gtid, original_commit_timestamp,
++                             immediate_commit_timestamp);
++
++        auto gtid_monitoring_info = mi->get_gtid_monitoring_info();
++        gtid_monitoring_info->update(
++            binary_log::transaction::compression::type::NONE,
++            compressed_transaction_bytes, uncompressed_transaction_bytes);
++      }
++    } else {
++      mi->transaction_parser.rollback();
++      is_error = true;
++    }
++
++    if (save_buf != nullptr) buf = save_buf;
++    if (is_error) {
++      // This error will be reported later at handle_slave_io().
++      goto err;
++    }
++  }
++  goto end;
++
++err:
++  res = QUEUE_EVENT_ERROR_QUEUING;
++
++end:
++  if (res == QUEUE_EVENT_OK && do_flush_mi) {
++    /*
++      Take a ride in the already locked LOCK_log to flush master info.
++
++      JAG: TODO: Notice that we could only flush master info if we are
++                 not in the middle of a transaction. Having a proper
++                 relay log recovery can allow us to do this.
++    */
++    if (lock_count == 1) {
++      mysql_mutex_lock(&mi->data_lock);
++      lock_count = 2;
++    }
++
++    if (flush_master_info(mi, true /*force*/, lock_count == 0 /*need_lock*/,
++                          false /*flush_relay_log*/, mi->is_gtid_only_mode()))
++      res = QUEUE_EVENT_ERROR_FLUSHING_INFO;
++    if (mi->is_gtid_only_mode()) {
++      mi->update_flushed_relay_log_info();
++    }
++  }
++  if (lock_count >= 2) mysql_mutex_unlock(&mi->data_lock);
++  if (lock_count >= 1) mysql_mutex_unlock(log_lock);
++  DBUG_PRINT("info", ("queue result: %d", res));
++  return res;
++}
++
+ /**
+   Hook to detach the active VIO before closing a connection handle.
+ 
+@@ -8638,6 +9253,14 @@ int flush_relay_logs(Master_info *mi, THD *thd) {
    if (mi) {
      Relay_log_info *rli = mi->rli;
      if (rli->inited) {
@@ -6990,7 +7458,7 @@ index 57dfb700ea5..c2817e34ad5 100644
        // Rotate immediately if one is true:
        if ((!is_group_replication_plugin_loaded() ||  // GR is disabled
             !mi->transaction_parser
-@@ -9331,6 +9534,16 @@ bool reset_slave_cmd(THD *thd) {
+@@ -9331,6 +9954,16 @@ bool reset_slave_cmd(THD *thd) {
        return true;
      }
  
@@ -7007,7 +7475,7 @@ index 57dfb700ea5..c2817e34ad5 100644
      if (mi)
        res = reset_slave(thd, mi, thd->lex->reset_slave_info.all);
      else if (strcmp(channel_map.get_default_channel(), lex->mi.channel))
-@@ -10997,6 +11210,14 @@ bool change_master_cmd(THD *thd) {
+@@ -10997,6 +11630,14 @@ bool change_master_cmd(THD *thd) {
      goto err;
    }
  
@@ -7022,6 +7490,20 @@ index 57dfb700ea5..c2817e34ad5 100644
    if (channel_map.is_group_replication_channel_name(lex->mi.channel, true)) {
      /*
        If the chosen name is for group_replication_applier channel we allow the
+diff --git a/sql/rpl_replica.h b/sql/rpl_replica.h
+index ee4add37b8f..83d1b7b7314 100644
+--- a/sql/rpl_replica.h
++++ b/sql/rpl_replica.h
+@@ -595,6 +595,9 @@ typedef enum {
+ } QUEUE_EVENT_RESULT;
+ QUEUE_EVENT_RESULT queue_event(Master_info *mi, const char *buf,
+                                ulong event_len, bool flush_mi = true);
++QUEUE_EVENT_RESULT queue_event_from_objstore(Master_info *mi, const char *buf,
++                                             ulong event_len,
++                                             bool do_flush_mi = true);
+ 
+ int heartbeat_queue_event(bool is_valid, Master_info *&mi,
+                           std::string binlog_name, uint64_t position,
 diff --git a/sql/rpl_rli.cc b/sql/rpl_rli.cc
 index 438c58fa82b..ed1e814d81a 100644
 --- a/sql/rpl_rli.cc
@@ -8841,7 +9323,7 @@ index 6c3dd85db23..8c43a67cd52 100644
          | HASH_SYM
          | HISTOGRAM_SYM
 diff --git a/sql/sys_vars.cc b/sql/sys_vars.cc
-index b16cb1830e4..b76c7e5e413 100644
+index b16cb1830e4..9924d84a1b7 100644
 --- a/sql/sys_vars.cc
 +++ b/sql/sys_vars.cc
 @@ -93,11 +93,13 @@
@@ -8937,7 +9419,7 @@ index b16cb1830e4..b76c7e5e413 100644
  
  static bool check_set_require_row_format(sys_var *, THD *thd, set_var *var) {
    /*
-@@ -7718,3 +7764,297 @@ static Sys_var_enum Sys_explain_format(
+@@ -7718,3 +7764,306 @@ static Sys_var_enum Sys_explain_format(
      SESSION_VAR(explain_format), CMD_LINE(OPT_ARG), explain_format_names,
      DEFAULT(static_cast<ulong>(Explain_format_type::TRADITIONAL)),
      NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr));
@@ -8996,6 +9478,24 @@ index b16cb1830e4..b76c7e5e413 100644
 +    "object store in parallel",
 +    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_binlog_archive_parallel_workers),
 +    CMD_LINE(REQUIRED_ARG), VALID_RANGE(1, MTS_MAX_WORKERS), DEFAULT(4),
++    BLOCK_SIZE(1));
++
++static Sys_var_bool Sys_binlog_archive_replica(
++    "binlog_archive_replica", "Indicate if binlog archive replica enable.",
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_binlog_archive_replica), CMD_LINE(OPT_ARG),
++    DEFAULT(false));
++
++static Sys_var_charptr Sys_binlog_archive_replica_source_log_file(
++    "binlog_archive_replica_source_log_file",
++    "The start source binlog file for snapshot archive replica",
++    GLOBAL_VAR(opt_binlog_archive_replica_source_log_file),
++    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT(nullptr));
++
++static Sys_var_ulong Sys_binlog_archive_replica_source_log_pos(
++    "binlog_archive_replica_source_log_pos",
++    "The start source binlog file position for snapshot archive replica",
++    GLOBAL_VAR(opt_binlog_archive_replica_source_log_pos),
++    CMD_LINE(REQUIRED_ARG), VALID_RANGE(1, ULONG_MAX), DEFAULT(4),
 +    BLOCK_SIZE(1));
 +
 +static Sys_var_bool Sys_snapshot_archive(
@@ -9089,74 +9589,65 @@ index b16cb1830e4..b76c7e5e413 100644
 +    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT(nullptr));
 +
 +static Sys_var_bool Sys_initialize_from_objstore(
-+    "initialize_from_objectstore",
-+    "Initialzie instance using binlog and snapshot from object "
++    "initialize_from_source_objectstore",
++    "Initialzie instance using binlog and snapshot from source object "
 +    "store.",
-+    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_from_objstore),
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_from_source_objectstore),
 +    CMD_LINE(OPT_ARG), DEFAULT(false));
 +
 +static Sys_var_charptr Sys_initialize_objstore_provider(
-+    "initialize_objectstore_provider",
-+    "The provider of object store as the source of data during instance."
-+    "If initialize_from_objectstore is true, it must not be "
-+    "empty.",
-+    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_objstore_provider),
++    "source_objectstore_provider",
++    "The provider of object store as the source of data during instance.",
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_source_objectstore_provider),
 +    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT("local"));
 +
 +static Sys_var_charptr Sys_initialize_objstore_region(
-+    "initialize_objectstore_region",
++    "source_objectstore_region",
 +    "The region of object store as the source of data during instance "
-+    "initialization."
-+    "If initialize_from_objectstore is true, it must not be "
-+    "empty.",
-+    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_objstore_region),
++    "initialization.",
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_source_objectstore_region),
 +    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT(".local_objectstore_region_1"));
 +
 +static Sys_var_charptr Sys_initialize_objstore_endpoint(
-+    "initialize_objectstore_endpoint",
++    "source_objectstore_endpoint",
 +    "The endpoint of object store as the source of data during instance "
 +    "initialization. "
-+    "If initialize_from_objectstore is true, user can specify the endpoint of "
-+    "object store. "
 +    "Ususally it's need to provide on non-AWS environment.",
-+    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_objstore_endpoint),
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_source_objectstore_endpoint),
 +    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT(nullptr));
 +
 +static Sys_var_bool Sys_initialize_objstore_use_https(
-+    "initialize_objectstore_use_https",
-+    "If initialize_from_objectstore is true, whether using https to connect to "
-+    "objstore or not "
++    "source_objectstore_use_https",
++    "Whether using https to connect to objstore or not "
 +    "as the source of data during instance initialization",
-+    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_objstore_use_https),
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_source_objectstore_use_https),
 +    CMD_LINE(OPT_ARG), DEFAULT(false));
 +
 +static Sys_var_charptr Sys_initialize_objstore_bucket(
-+    "initialize_objectstore_bucket",
++    "source_objectstore_bucket",
 +    "The object store bucket to store record as the source of data during "
-+    "instance initialization. If initialize_from_objectstore is true, it must "
-+    "not be empty.",
-+    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_objstore_bucket),
++    "instance initialization. ",
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_source_objectstore_bucket),
 +    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT("objectstore_bucket_1"));
 +
 +static Sys_var_charptr Sys_initialize_repo_objstore_id(
-+    "initialize_repo_objectstore_id",
-+    "The repo identifier for data directory of source cluster in object store. "
-+    "If initialize_from_objectstore is true, it must not be empty.",
-+    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_repo_objstore_id),
++    "source_objectstore_repo_id",
++    "The repo identifier for data directory of source cluster in object store. ",
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_source_objectstore_repo_id),
 +    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT("wesql_serverless_repo"));
 +
 +static Sys_var_charptr Sys_initialize_branch_objstore_id(
-+    "initialize_branch_objectstore_id",
++    "source_objectstore_branch_id",
 +    "The branch identifier for data directory of source cluster in object store.",
-+    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_initialize_branch_objstore_id),
++    READ_ONLY NON_PERSIST GLOBAL_VAR(opt_source_objectstore_branch_id),
 +    CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET, DEFAULT("main"));
 +
-+static Sys_var_bool Sys_initialize_smartengine_objectstore_data(
-+    "initialize_smartengine_objectstore_data",
-+    "If initialize_from_objectstore is true, whether initialize smartengine "
++static Sys_var_bool Sys_source_objectstore_smartengine_data(
++    "source_objectstore_smartengine_data",
++    "Whether initialize smartengine "
 +    "object store data from source cluster object store.",
 +    READ_ONLY NON_PERSIST
-+        GLOBAL_VAR(opt_initialize_smartengine_objectstore_data),
++        GLOBAL_VAR(opt_source_objectstore_smartengine_data),
 +    CMD_LINE(OPT_ARG), DEFAULT(false));
 +
 +static Sys_var_bool Sys_enable_serverless(

--- a/plugin/raft_replication/consensus_binlog.cc
+++ b/plugin/raft_replication/consensus_binlog.cc
@@ -1790,6 +1790,11 @@ int write_rotate_event_into_consensus_log(MYSQL_BIN_LOG *binlog) {
 
   // don't be ignored by slave SQL thread
   r.server_id = 0;
+  r.pos = binlog_file_get_current_pos(binlog->get_binlog_file()) +
+          LOG_EVENT_HEADER_LEN + r.get_data_size() +
+          (binlog_checksum_options != binary_log::BINLOG_CHECKSUM_ALG_OFF
+               ? BINLOG_CHECKSUM_LEN
+               : 0);
   r.common_header->when.tv_sec = consensus_log_manager.get_event_timestamp();
 
   return binlog_write_event_directly(binlog, &r);

--- a/sql/binlog_archive.cc
+++ b/sql/binlog_archive.cc
@@ -96,12 +96,13 @@ static PSI_file_key PSI_binlog_archive_log_index_key;
 static PSI_file_key PSI_binlog_archive_log_index_cache_key;
 
 static PSI_thread_info all_binlog_archive_threads[] = {
-    {&THR_KEY_binlog_archive, "archive", "bin_arch", PSI_FLAG_AUTO_SEQNUM, 0,
-     PSI_DOCUMENT_ME},
-    {&THR_KEY_binlog_archive_worker, "archive", "bin_arch_w",
-     PSI_FLAG_AUTO_SEQNUM, 0, PSI_DOCUMENT_ME},
-    {&THR_KEY_binlog_archive_update_index_worker, "archive", "bin_arch_i",
-     PSI_FLAG_AUTO_SEQNUM, 0, PSI_DOCUMENT_ME}};
+    {&THR_KEY_binlog_archive, "binlog_arch", "bin_ac",
+     PSI_FLAG_SINGLETON | PSI_FLAG_THREAD_SYSTEM, 0, PSI_DOCUMENT_ME},
+    {&THR_KEY_binlog_archive_worker, "binlog_arch_io", "bin_ac_io",
+     PSI_FLAG_AUTO_SEQNUM | PSI_FLAG_THREAD_SYSTEM, 0, PSI_DOCUMENT_ME},
+    {&THR_KEY_binlog_archive_update_index_worker, "binlog_arch_update_index",
+     "bin_ac_update", PSI_FLAG_SINGLETON | PSI_FLAG_THREAD_SYSTEM, 0,
+     PSI_DOCUMENT_ME}};
 
 static PSI_mutex_info all_binlog_archive_mutex_info[] = {
     {&PSI_binlog_archive_lock_key, "binlog_archive::mutex", 0, 0,
@@ -681,6 +682,7 @@ int start_binlog_archive() {
 void stop_binlog_archive() {
   DBUG_TRACE;
   DBUG_PRINT("info", ("stop_binlog_archive"));
+  if (!opt_binlog_archive || !opt_serverless) return;
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_LOG, "terminate begin");
 
   mysql_mutex_lock(&m_binlog_archive_run_lock);
@@ -1744,22 +1746,22 @@ int Binlog_archive::archive_events(File_reader &reader, my_off_t end_pos) {
  * into the same persistent binlog.
  */
 int Binlog_archive::archive_event(File_reader &reader, uchar *event_ptr,
-                                  uint32 event_len, const char *log_file,
+                                  uint32 event_len, const char *mysql_log_file,
                                   my_off_t log_pos) {
   DBUG_TRACE;
   DBUG_PRINT("info", ("archive_event"));
   DBUG_EXECUTE_IF("fault_injection_archive_event", { return 1; });
   int error = 0;
-  assert(log_file != nullptr);
+  assert(mysql_log_file != nullptr);
   assert(log_pos >= BIN_LOG_HEADER_SIZE);
 
   Log_event_type type = (Log_event_type)event_ptr[EVENT_TYPE_OFFSET];
   uint32 len = uint4korr(event_ptr + EVENT_LEN_OFFSET);
   assert(len == event_len);
-  my_off_t event_start_pos = reader.event_start_pos();
-  uint32 event_end_pos = uint4korr(event_ptr + LOG_POS_OFFSET);
-  assert((event_start_pos + event_len) == event_end_pos);
-  assert(event_end_pos == log_pos);
+  my_off_t mysql_event_start_pos = reader.event_start_pos();
+  uint32 mysql_event_end_pos = uint4korr(event_ptr + LOG_POS_OFFSET);
+  assert((mysql_event_start_pos + event_len) == mysql_event_end_pos);
+  assert(mysql_event_end_pos == log_pos);
 
   DBUG_PRINT("info",
              ("Archiving event of type %s", Log_event::get_type_str(type)));
@@ -1779,7 +1781,7 @@ int Binlog_archive::archive_event(File_reader &reader, uchar *event_ptr,
     }
 
     // switch next mysql binlog and generate first slice.
-    if (new_binlog_slice(true, log_file, log_pos,
+    if (new_binlog_slice(true, mysql_log_file,
                          m_mysql_binlog_previouse_consensus_index)) {
       error = 1;
       goto err_slice;
@@ -1797,8 +1799,8 @@ int Binlog_archive::archive_event(File_reader &reader, uchar *event_ptr,
     m_binlog_last_event_type_str = Log_event::get_type_str(type);
     m_slice_bytes_written += event_len;
     // Update the last archived event end of position.
-    m_binlog_archive_write_last_event_end_pos = event_end_pos;
-    m_mysql_binlog_write_last_event_end_pos = event_end_pos;
+    m_binlog_archive_write_last_event_end_pos = mysql_event_end_pos;
+    m_mysql_binlog_write_last_event_end_pos = mysql_event_end_pos;
     mysql_mutex_unlock(&m_rotate_lock);
     goto suc;
   } else {
@@ -1856,38 +1858,86 @@ int Binlog_archive::archive_event(File_reader &reader, uchar *event_ptr,
   // leader.
   if (m_slice_cache.empty()) {
     assert(log_pos > BIN_LOG_HEADER_SIZE);
-    if (new_binlog_slice(false, log_file, log_pos, 0)) {
+    if (new_binlog_slice(false, mysql_log_file, 0)) {
       error = 1;
       goto err_slice;
     }
   }
 
+  // If rotate event , need reconstruct the rotate event with
+  // persistent binlog file name.
+  if (type == binary_log::ROTATE_EVENT) {
+    uchar *old_rotate_header = event_ptr + LOG_EVENT_HEADER_LEN;
+    my_off_t old_rotate_header_pos = uint8korr(old_rotate_header);
+    char new_binlog[FN_REFLEN + 1] = {0};
+
+    if (old_rotate_header_pos == LOG_EVENT_OFFSET) {
+      // reconstruct the last rotate event in binlog file.
+      snprintf(new_binlog, sizeof(new_binlog) - 1, BINLOG_ARCHIVE_FILE_FORMAT,
+               static_cast<my_off_t>(m_binlog_archive_last_index_number + 1));
+    } else {
+      // Reconstruct the intermediate Rotate event in the binlog file. These
+      // Rotate events record the current file information for applying the
+      // barrier.
+      assert(old_rotate_header_pos > LOG_EVENT_OFFSET);
+      strmake(new_binlog, m_binlog_archive_file_name, sizeof(new_binlog) - 1);
+    }
+
+    size_t ident_len = strlen(new_binlog);
+    uint32 rotate_event_len = ident_len + LOG_EVENT_HEADER_LEN +
+                              Binary_log_event::ROTATE_HEADER_LEN +
+                              (event_checksum_on() ? BINLOG_CHECKSUM_LEN : 0);
+    size_t event_offset = m_packet.length();
+    m_packet.length(rotate_event_len + event_offset);
+    uchar *header = pointer_cast<uchar *>(m_packet.ptr()) + event_offset;
+    uchar *rotate_header = header + LOG_EVENT_HEADER_LEN;
+
+    int4store(header, uint4korr(event_ptr));  // timestamp
+    header[EVENT_TYPE_OFFSET] = binary_log::ROTATE_EVENT;
+    int4store(header + SERVER_ID_OFFSET,
+              uint4korr(event_ptr + SERVER_ID_OFFSET));
+    int4store(header + EVENT_LEN_OFFSET, static_cast<uint32>(rotate_event_len));
+    int4store(header + LOG_POS_OFFSET,
+              m_binlog_archive_write_last_event_end_pos + rotate_event_len);
+    int2store(header + FLAGS_OFFSET, 0);
+
+    if (old_rotate_header_pos == LOG_EVENT_OFFSET) {
+      int8store(rotate_header, LOG_EVENT_OFFSET);
+    } else {
+      assert(old_rotate_header_pos > LOG_EVENT_OFFSET);
+      int8store(rotate_header,
+                m_binlog_archive_write_last_event_end_pos + rotate_event_len);
+    }
+
+    memcpy(rotate_header + Binary_log_event::ROTATE_HEADER_LEN, new_binlog,
+           ident_len);
+
+    if (event_checksum_on()) calc_event_checksum(header, rotate_event_len);
+    event_ptr = header;
+    event_len = rotate_event_len;
+    // mysql_event_end_pos = m_binlog_archive_write_last_event_end_pos +
+    // event_len;
+  }
+
   m_binlog_last_event_type = type;
   m_binlog_last_event_type_str = Log_event::get_type_str(type);
   m_slice_bytes_written += event_len;
-  // Record the last archived event end of position.
+  // Record the last write archive cache event end of position.
   m_binlog_archive_write_last_event_end_pos += event_len;
-  m_mysql_binlog_write_last_event_end_pos = event_end_pos;
+  m_mysql_binlog_write_last_event_end_pos = mysql_event_end_pos;
 
   // Here, the primary consideration is that the new Leader's current
   // `binlog.000004` event needs to be persisted into the `binlog.000001` file
   // generated by the old Leader. However, the structures of these two binlogs
-  // might differ, so it may be necessary to adjust the `event_end_pos` of each
-  // event.
-  if (m_mysql_binlog_first_file) {
-    if (event_end_pos != m_binlog_archive_write_last_event_end_pos) {
-      int4store(event_ptr + LOG_POS_OFFSET,
-                static_cast<uint32>(m_binlog_archive_write_last_event_end_pos));
-      if (event_checksum_on()) {
-        calc_event_checksum(event_ptr, event_len);
-      }
-      event_end_pos = uint4korr(event_ptr + LOG_POS_OFFSET);
-    }
-  } else {
-    assert(m_binlog_archive_write_last_event_end_pos ==
-           m_mysql_binlog_write_last_event_end_pos);
+  // might differ, so it may be necessary to adjust the `mysql_event_end_pos` of
+  // each event.
+  // Or after recontructing the Rotate event, then the subsequent events in the
+  // binlog file need to have their positions (pos) adjusted.
+  if (mysql_event_end_pos != m_binlog_archive_write_last_event_end_pos) {
+    int4store(event_ptr + LOG_POS_OFFSET,
+              static_cast<uint32>(m_binlog_archive_write_last_event_end_pos));
+    if (event_checksum_on()) calc_event_checksum(event_ptr, event_len);
   }
-  assert(m_binlog_archive_write_last_event_end_pos == event_end_pos);
   m_slice_cache.append(reinterpret_cast<const char *>(event_ptr), event_len);
 
   // rotate binlog slice, if the binlog slice size is too large.
@@ -2212,8 +2262,8 @@ std::pair<my_off_t, int> Binlog_archive::get_binlog_end_pos(
  * @return int
  * @note Must be called with m_rotate_lock held.
  */
-int Binlog_archive::new_binlog_slice(bool new_binlog, const char *log_file,
-                                     my_off_t log_pos [[maybe_unused]],
+int Binlog_archive::new_binlog_slice(bool new_binlog,
+                                     const char *mysql_log_file,
                                      uint64_t previous_consensus_index) {
   DBUG_TRACE;
   DBUG_PRINT("info", ("new_binlog_slice"));
@@ -2231,7 +2281,7 @@ int Binlog_archive::new_binlog_slice(bool new_binlog, const char *log_file,
     // The first persisted binlog.
     if (m_mysql_end_consensus_index == 0)
       m_mysql_end_consensus_index = previous_consensus_index;
-    strmake(m_mysql_binlog_file_name, log_file,
+    strmake(m_mysql_binlog_file_name, mysql_log_file,
             sizeof(m_mysql_binlog_file_name) - 1);
     // The maximum length of the string representation of
     // m_binlog_archive_last_index_number does not exceed 20

--- a/sql/binlog_archive.cc
+++ b/sql/binlog_archive.cc
@@ -269,7 +269,8 @@ void *Binlog_archive_worker::worker_thread() {
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id,
          "thread running");
   while (true) {
-    uint32_t retry = 5;
+    int failure_trials =
+        Binlog_archive::MAX_RETRIES_FOR_OBJECT_MANIPULATION_FAILURE;
     Binlog_expected_slice slice;
     bool is_slice_persisted = false;
     uint64_t slice_queue_map_term = 0;
@@ -307,7 +308,7 @@ void *Binlog_archive_worker::worker_thread() {
     m_current_slice = slice;
 
     // Persist the slice to the object store.
-    while (retry-- > 0) {
+    while (failure_trials-- > 0) {
       bool error = false;
       DBUG_EXECUTE_IF("fault_injection_put_slice_to_objstore", {
         LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_WORKER_LOG, m_worker_id,

--- a/sql/binlog_archive.h
+++ b/sql/binlog_archive.h
@@ -371,8 +371,6 @@ class Binlog_archive {
   bool is_thread_dead() const { return m_thd_state.is_thread_dead(); }
   bool is_thread_alive() const { return m_thd_state.is_thread_alive(); }
   bool is_thread_running() const { return m_thd_state.is_running(); }
-  int archive_event(File_reader &reader, uchar *event_ptr, uint32 event_len,
-                    const char *log_file, my_off_t log_pos);
   int binlog_stop_waiting_for_archive(const char *log_file_name,
                                       char *persistent_log_file_name,
                                       my_off_t log_pos,
@@ -501,7 +499,7 @@ class Binlog_archive {
       m_slice_end_consensus_index;  // end consensus index of persisted binlogs.
   uint64 m_mysql_end_consensus_index;  // end consensus index of readed mysql
                                        // binlogs.
-  int new_binlog_slice(bool new_binlog, const char *log_file, my_off_t log_pos,
+  int new_binlog_slice(bool new_binlog, const char *mysql_log_file,
                        uint64_t previous_consensus_index);
   int archive_init();
   int archive_cleanup();
@@ -510,6 +508,8 @@ class Binlog_archive {
   int archive_binlog(File_reader &reader, my_off_t start_pos);
   std::pair<my_off_t, int> get_binlog_end_pos(File_reader &reader);
   int archive_events(File_reader &reader, my_off_t end_pos);
+  int archive_event(File_reader &reader, uchar *event_ptr, uint32 event_len,
+                    const char *mysql_log_file, my_off_t log_pos);
   int read_format_description_event(File_reader &reader);
   int wait_new_mysql_binlog_events(my_off_t log_pos);
   int new_persistent_binlog_slice_key(const char *binlog,

--- a/sql/binlog_archive.h
+++ b/sql/binlog_archive.h
@@ -426,6 +426,7 @@ class Binlog_archive {
                               bool is_slice_persisted,
                               uint64_t slice_queue_map_term);
   bool update_index_file(bool need_slice_lock);
+  static const int MAX_RETRIES_FOR_OBJECT_MANIPULATION_FAILURE = 5;
 
  private:
   // the binlog archive THD handle.

--- a/sql/binlog_archive_replica.cc
+++ b/sql/binlog_archive_replica.cc
@@ -1,0 +1,2219 @@
+/*
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#include "sql/binlog_archive_replica.h"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "libbinlogevents/include/binlog_event.h"  // binary_log::max_log_event_size
+#include "mf_wcomp.h"                              // wild_one, wild_many
+#include "my_dbug.h"
+#include "my_thread.h"
+#include "mysql/components/services/log_builtins.h"  // LogErr
+#include "mysql/components/services/log_shared.h"
+#include "mysql/psi/mysql_file.h"
+#include "mysql/psi/mysql_thread.h"
+#include "objstore.h"
+#include "sql/basic_istream.h"
+#include "sql/basic_ostream.h"
+#include "sql/binlog.h"
+#include "sql/binlog_istream.h"
+#include "sql/binlog_ostream.h"
+#include "sql/binlog_reader.h"
+#include "sql/changestreams/apply/replication_thread_status.h"
+#include "sql/consensus_log_event.h"
+#include "sql/consistent_archive.h"
+#include "sql/debug_sync.h"
+#include "sql/derror.h"
+#include "sql/log.h"
+#include "sql/log_event.h"
+#include "sql/mdl.h"
+#include "sql/mysqld.h"
+#include "sql/mysqld_thd_manager.h"
+#include "sql/protocol_classic.h"
+#include "sql/rpl_handler.h"
+#include "sql/rpl_io_monitor.h"
+#include "sql/rpl_msr.h"
+#include "sql/rpl_source.h"
+#include "sql/sql_lex.h"
+#include "sql/sql_parse.h"
+#include "unsafe_string_append.h"
+
+// Global binlog archive thread object
+static Binlog_archive_replica mysql_binlog_archive_replica;
+static my_thread_handle mysql_binlog_archive_replica_pthd;
+
+static mysql_mutex_t m_binlog_archive_replica_run_lock;
+static mysql_cond_t m_binlog_archive_replica_run_cond;
+
+#ifdef HAVE_PSI_INTERFACE
+static PSI_thread_key THR_KEY_binlog_archive_replica;
+static PSI_thread_key THR_KEY_binlog_archive_io_worker;
+static PSI_thread_key THR_KEY_binlog_archive_replica_relay_worker;
+static PSI_mutex_key PSI_binlog_archive_replica_lock_key;
+static PSI_cond_key PSI_binlog_archive_replica_cond_key;
+static PSI_mutex_key PSI_binlog_archive_replica_io_worker_lock_key;
+static PSI_cond_key PSI_binlog_archive_replica_io_worker_cond_key;
+static PSI_mutex_key PSI_binlog_archive_replica_relay_worker_lock_key;
+static PSI_cond_key PSI_binlog_archive_replica_relay_worker_cond_key;
+static PSI_mutex_key PSI_binlog_index_lock_key;
+
+static PSI_mutex_key PSI_binlog_slice_lock_key;
+static PSI_cond_key PSI_binlog_slice_queue_cond_key;
+static PSI_cond_key PSI_binlog_slice_map_cond_key;
+
+/** The instrumentation key to use for opening the log index file. */
+static PSI_file_key PSI_binlog_archive_log_index_key;
+/** The instrumentation key to use for opening a log index cache file. */
+static PSI_file_key PSI_binlog_archive_log_index_cache_key;
+
+// The name lenght include a terminating NUL character of thread can not exceed
+// 12 characters, if flag is not PSI_FLAG_SINGLETON | PSI_FLAG_NO_SEQNUM.
+static PSI_thread_info all_binlog_archive_threads[] = {
+    {&THR_KEY_binlog_archive_replica, "binlog_arch_rpl", "bin_ac_rpl",
+     PSI_FLAG_SINGLETON | PSI_FLAG_THREAD_SYSTEM, 0, PSI_DOCUMENT_ME},
+    {&THR_KEY_binlog_archive_io_worker, "binlog_arch_rpl_io", "bin_ac_rpl_i",
+     PSI_FLAG_AUTO_SEQNUM | PSI_FLAG_THREAD_SYSTEM, 0, PSI_DOCUMENT_ME},
+    {&THR_KEY_binlog_archive_replica_relay_worker, "binlog_arch_rpl_relay",
+     "bin_ac_rpl_r", PSI_FLAG_SINGLETON | PSI_FLAG_THREAD_SYSTEM, 0,
+     PSI_DOCUMENT_ME}};
+
+static PSI_mutex_info all_binlog_archive_mutex_info[] = {
+    {&PSI_binlog_archive_replica_lock_key, "binlog_archive_replica::mutex", 0,
+     0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_replica_io_worker_lock_key,
+     "binlog_archive_replica::mutex", 0, 0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_replica_relay_worker_lock_key,
+     "binlog_archive_replica::mutex", 0, 0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_slice_lock_key, "binlog_archive_index::mutex", 0, 0,
+     PSI_DOCUMENT_ME},
+    {&PSI_binlog_index_lock_key, "binlog_archive_index::mutex", 0, 0,
+     PSI_DOCUMENT_ME}};
+
+static PSI_cond_info all_binlog_archive_cond_info[] = {
+    {&PSI_binlog_archive_replica_cond_key, "binlog_archive_replica::condition",
+     0, 0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_replica_io_worker_cond_key,
+     "binlog_archive_replica::condition", 0, 0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_replica_relay_worker_cond_key,
+     "binlog_archive_replica::condition", 0, 0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_slice_queue_cond_key, "binlog_archive_replica::condition", 0,
+     0, PSI_DOCUMENT_ME},
+    {&PSI_binlog_slice_map_cond_key, "binlog_archive_replica::condition", 0, 0,
+     PSI_DOCUMENT_ME}};
+
+static PSI_file_info all_binlog_archive_files[] = {
+    {&PSI_binlog_archive_log_index_key, "binlog_archive_index", 0, 0,
+     PSI_DOCUMENT_ME},
+    {&PSI_binlog_archive_log_index_cache_key, "binlog_archive_index_cache", 0,
+     0, PSI_DOCUMENT_ME}};
+#endif
+
+static void *mysql_binlog_archive_replica_action(void *arg);
+static bool remove_file(const std::string &file);
+static int compare_log_name(const char *log_1, const char *log_2);
+static THD *set_thread_context();
+
+/**
+ * @brief
+ *
+ * @return int
+ */
+int Binlog_archive_replica::channel_create() {
+  DBUG_TRACE;
+  Master_info *mi = nullptr;
+  std::string err_msg;
+  int error = 0;
+
+  channel_map.wrlock();
+  /* Get the Master_info of the channel */
+  mi = channel_map.get_mi(BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME);
+
+  if (mi) {
+    goto err;
+  }
+  /* create a new binlog archive replica channel if doesn't exist */
+  // set global relay_log_recovery=true
+  // For the first creation of an mi, the locally restored latest consensus
+  // index is used as the starting synchronization point with the source object
+  // storage.
+  err_msg.assign("create binlog archive channel ");
+  err_msg.append(BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME);
+  if ((error = add_new_channel(&mi, BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME))) {
+    err_msg.append(" failed");
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, "add_new_channel failed");
+    goto err;
+  }
+  err_msg.append(" success");
+  LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+  if ((error = load_mi_and_rli_from_repositories(
+           mi, false, SLAVE_IO | SLAVE_SQL, false, true)))
+    goto err;
+  // Initialize the channel master info start binlog and position with the
+  // source object storage
+  if (opt_binlog_archive_replica_source_log_file != nullptr) {
+    mysql_mutex_lock(mi->rli->relay_log.get_log_lock());
+    mysql_mutex_lock(&mi->data_lock);
+    mi->set_master_log_name(opt_binlog_archive_replica_source_log_file);
+    mi->set_master_log_pos(opt_binlog_archive_replica_source_log_pos);
+    // Flush the master info to the repository
+    flush_master_info(mi, true, false);
+    mysql_mutex_unlock(&mi->data_lock);
+    mysql_mutex_unlock(mi->rli->relay_log.get_log_lock());
+
+    err_msg.assign("init binlog replica channel master info position");
+    err_msg.append(mi->get_for_channel_str());
+    err_msg.append(" file=");
+    err_msg.append(mi->get_master_log_name());
+    err_msg.append(" pos=");
+    err_msg.append(std::to_string(mi->get_master_log_pos()));
+    // print the current replication position
+    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+  }
+
+err:
+  channel_map.unlock();
+
+  return error;
+}
+
+int Binlog_archive_replica::channel_start() {
+  Master_info *mi = nullptr;
+  std::string err_msg;
+  int error = 0;
+  LEX_SLAVE_CONNECTION lex_connection;
+  LEX_MASTER_INFO *lex_mi;
+  lex_mi = new LEX_MASTER_INFO();
+
+  channel_map.wrlock();
+  /* Get the Master_info of the channel */
+  mi = channel_map.get_mi(BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME);
+
+  if (mi == nullptr) {
+    goto err;
+  }
+
+  /*
+    Read the channel configuration from the repository if the channel name
+    was read from the repository.
+    load_mi_and_rli_from_repositories -> rli_init_info() -> init_recovery
+  */
+  if ((error = load_mi_and_rli_from_repositories(
+           mi, false, SLAVE_IO | SLAVE_SQL, false, true)))
+    goto err;
+  err_msg.assign(
+      "load binlog archive replica channel master info and rli info");
+  err_msg.append(mi->get_for_channel_str());
+  err_msg.append(" file=");
+  err_msg.append(mi->get_master_log_name());
+  err_msg.append(" pos=");
+  err_msg.append(std::to_string(mi->get_master_log_pos()));
+  // print the current replication position
+  LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+
+  lex_mi->channel = BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME;
+  lex_connection.reset();
+
+  mi->rli->opt_replica_parallel_workers = opt_mts_replica_parallel_workers;
+  mi->rli->checkpoint_group = opt_mta_checkpoint_group;
+  if (mts_parallel_option == MTS_PARALLEL_TYPE_DB_NAME)
+    mi->rli->channel_mts_submode = MTS_PARALLEL_TYPE_DB_NAME;
+  else
+    mi->rli->channel_mts_submode = MTS_PARALLEL_TYPE_LOGICAL_CLOCK;
+  // Startup applier threads
+  if ((error =
+           start_slave(m_thd, &lex_connection, lex_mi, SLAVE_SQL, mi, false))) {
+    goto err;
+  }
+
+  // Init master format description event
+  mysql_mutex_lock(mi->rli->relay_log.get_log_lock());
+  mysql_mutex_lock(&mi->data_lock);
+  mi->set_mi_description_event(new Format_description_log_event());
+  /* as we are here, we tried to allocate the event */
+  if (mi->get_mi_description_event() == nullptr) {
+    mysql_mutex_unlock(&mi->data_lock);
+    mysql_mutex_unlock(mi->rli->relay_log.get_log_lock());
+    goto err;
+  }
+  mi->get_mi_description_event()->common_footer->checksum_alg =
+      mi->rli->relay_log.relay_log_checksum_alg;
+  assert(mi->get_mi_description_event()->common_footer->checksum_alg !=
+         binary_log::BINLOG_CHECKSUM_ALG_UNDEF);
+  assert(mi->rli->relay_log.relay_log_checksum_alg !=
+         binary_log::BINLOG_CHECKSUM_ALG_UNDEF);
+  mysql_mutex_unlock(&mi->data_lock);
+  mysql_mutex_unlock(mi->rli->relay_log.get_log_lock());
+
+  m_master_info = mi;
+err:
+  channel_map.unlock();
+  delete lex_mi;
+  return error;
+}
+
+int Binlog_archive_replica::channel_stop() {
+  int error = 0;
+  channel_map.wrlock();
+  Master_info *mi = channel_map.get_mi(BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME);
+
+  if (mi == nullptr) {
+    error = 1;
+    goto err;
+  }
+
+  mi->channel_wrlock();
+  lock_slave_threads(mi);
+  m_thd->set_skip_readonly_check();
+  error =
+      terminate_slave_threads(mi, SLAVE_SQL, rpl_stop_replica_timeout, false);
+  m_thd->reset_skip_readonly_check();
+  unlock_slave_threads(mi);
+  mi->channel_unlock();
+err:
+  channel_map.unlock();
+  return error;
+}
+
+/**
+ * @brief Check if the binlog archive replica applier thread is running.
+ *
+ * @return true
+ * @return false
+ */
+bool Binlog_archive_replica::channel_is_running() {
+  DBUG_TRACE;
+  bool is_running = false;
+
+  channel_map.wrlock();
+  Master_info *mi = channel_map.get_mi(BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME);
+  if (mi == nullptr) {
+    goto err;
+  }
+  mysql_mutex_lock(&mi->rli->run_lock);
+  is_running = mi->rli->slave_running;
+  mysql_mutex_unlock(&mi->rli->run_lock);
+
+err:
+  channel_map.unlock();
+  return is_running;
+}
+
+Binlog_archive_replica_io_worker::Binlog_archive_replica_io_worker(
+    Binlog_archive_replica *archive, int worker_id)
+    : m_archive(archive),
+      m_worker_id(worker_id),
+      m_current_slice(),
+      m_thd(nullptr),
+      m_thd_state(),
+      atomic_binlog_archive_replica_io_worker_waiting(true) {
+  mysql_mutex_init(PSI_binlog_archive_replica_io_worker_lock_key,
+                   &m_worker_run_lock, MY_MUTEX_INIT_FAST);
+  mysql_cond_init(PSI_binlog_archive_replica_io_worker_cond_key,
+                  &m_worker_run_cond);
+}
+
+Binlog_archive_replica_io_worker::~Binlog_archive_replica_io_worker() {
+  stop();
+  mysql_mutex_destroy(&m_worker_run_lock);
+  mysql_cond_destroy(&m_worker_run_cond);
+}
+
+/**
+ * @brief Start the binlog archive replica io worker thread.
+ * @return true if the worker thread was successfully started, false otherwise.
+ */
+bool Binlog_archive_replica_io_worker::start() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("start"));
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+         "starting");
+  mysql_mutex_lock(&m_worker_run_lock);
+  if (mysql_thread_create(THR_KEY_binlog_archive_io_worker, &m_thread,
+                          &connection_attrib, thread_launcher, (void *)this)) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+           "start failed");
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return false;
+  }
+  thread_set_created();
+  while (is_thread_alive_not_running()) {
+    DBUG_PRINT(
+        "sleep",
+        ("Waiting for binlog archive replica io worker thread to start"));
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_worker_run_cond, &m_worker_run_lock, &abstime);
+  }
+  mysql_mutex_unlock(&m_worker_run_lock);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+         "started");
+  return true;
+}
+
+void Binlog_archive_replica_io_worker::stop() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("stop"));
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+         "terminate begin");
+  mysql_mutex_lock(&m_worker_run_lock);
+  if (is_thread_dead()) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+           "terminated");
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return;
+  }
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+         "terminating binlog archive replica io worker");
+  mysql_mutex_unlock(&m_worker_run_lock);
+  terminate_binlog_archive_replica_io_worker_thread();
+  /* Wait until the thread is terminated. */
+  my_thread_join(&m_thread, nullptr);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+         "terminate end");
+}
+
+/**
+ * @brief Binlog archive thread terminate worker thread.
+ *
+ * @return true if the worker thread was successfully terminated, false
+ * otherwise.
+ */
+int Binlog_archive_replica_io_worker::
+    terminate_binlog_archive_replica_io_worker_thread() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("terminate_binlog_archive_replica_io_worker_thread"));
+  mysql_mutex_lock(&m_worker_run_lock);
+  while (m_thd_state.is_thread_alive()) {
+    DBUG_PRINT("sleep",
+               ("Waiting for binlog archive replica io worker to stop"));
+    if (m_thd_state.is_initialized()) {
+      mysql_mutex_lock(&m_thd->LOCK_thd_data);
+      m_thd->awake(THD::KILL_CONNECTION);
+      mysql_mutex_unlock(&m_thd->LOCK_thd_data);
+    }
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_worker_run_cond, &m_worker_run_lock, &abstime);
+  }
+  assert(m_thd_state.is_thread_dead());
+  mysql_mutex_unlock(&m_worker_run_lock);
+  return 0;
+}
+
+/**
+ * @brief Worker thread function for pulling binlog slices from object
+ * store to local.
+ * @return void* Thread return value (nullptr)
+ */
+void *Binlog_archive_replica_io_worker::worker_thread() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("worker_thread"));
+  Binlog_archive_replica *archive = m_archive;
+  std::string err_msg;
+
+  m_thd = set_thread_context();
+
+  mysql_mutex_lock(&m_worker_run_lock);
+  m_thd_state.set_running();
+  mysql_cond_broadcast(&m_worker_run_cond);
+  mysql_mutex_unlock(&m_worker_run_lock);
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+         "thread running");
+  while (true) {
+    uint32_t retry = 5;
+    Binlog_expected_pull_slice slice;
+    bool is_slice_pull = false;
+
+    mysql_mutex_lock(&archive->m_slice_mutex);
+    // Wait for the slice key to be available.
+    m_thd->ENTER_COND(&archive->m_queue_cond, &archive->m_slice_mutex, nullptr,
+                      nullptr);
+    set_binlog_archive_replica_io_worker_waiting(true);
+    while (archive->m_expected_slice_queue.empty() &&
+           !unlikely(m_thd->killed)) {
+      // Wait for signal from the index worker thread that the new expected
+      // slice key is added to the queue. Or the worker thread is killed.
+      mysql_cond_wait(&archive->m_queue_cond, &archive->m_slice_mutex);
+    }
+    // When the worker thread is killed, exit.
+    if (unlikely(m_thd->killed)) {
+      mysql_mutex_unlock(&archive->m_slice_mutex);
+      m_thd->EXIT_COND(nullptr);
+      break;
+    }
+    // The io worker thread is no longer waiting.
+    set_binlog_archive_replica_io_worker_waiting(false);
+    // Get the slice key from the queue.
+    archive->m_expected_slice_queue.de_queue(&slice);
+    mysql_mutex_unlock(&archive->m_slice_mutex);
+    m_thd->EXIT_COND(nullptr);
+
+    // Signal the binlog archive replica thread that maybe wait, because the
+    // slice queue maybe full.
+    mysql_cond_signal(&archive->m_queue_cond);
+    m_current_slice = slice;
+    std::string slice_data_cache;
+    // pull the slice to the local cache.
+    while (retry-- > 0) {
+      bool error = false;
+      err_msg.assign(" get slice object ");
+      err_msg.append(slice.m_slice_keyid);
+      DBUG_EXECUTE_IF("simulate_get_slice_object_error_on_io_worker", {
+        err_msg.append(" error=");
+        err_msg.append("simulate_get_slice_object_error_on_io_worker");
+        LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+               err_msg.c_str());
+        error = true;
+      });
+      if (error) {
+        is_slice_pull = false;
+        break;
+      }
+
+      objstore::Status ss = m_archive->get_objstore()->get_object(
+          std::string_view(opt_source_objectstore_bucket),
+          std::string_view(slice.m_slice_keyid), slice_data_cache);
+      err_msg.append(" size=");
+      err_msg.append(std::to_string(slice_data_cache.size()));
+      err_msg.append(" ");
+      err_msg.append(std::to_string(slice.m_file_seq));
+      err_msg.append("/");
+      err_msg.append(std::to_string(slice.m_slice_seq));
+
+      if (!ss.is_succ()) {
+        err_msg.append(" error=");
+        err_msg.append(ss.error_message());
+        LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+               err_msg.c_str());
+        my_sleep(1000);
+        is_slice_pull = false;
+        continue;
+      }
+      is_slice_pull = true;
+      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+             err_msg.c_str());
+      break;
+    }
+    // Notify the binlog archive relay worker that the slice has been
+    // pull.
+    err_msg.assign("slice pull ");
+    err_msg.append("file_seq=");
+    err_msg.append(std::to_string(slice.m_file_seq));
+    err_msg.append(" slice_seq=");
+    err_msg.append(std::to_string(slice.m_slice_seq));
+    err_msg.append(" log_slice_keyid=");
+    err_msg.append(slice.m_slice_keyid);
+
+    mysql_mutex_lock(&archive->m_slice_mutex);
+    // If the slice status map is empty or the slice status is not found in the
+    // map, there is no need to update the slice status map. Skip the update.
+    if (archive->m_slice_status_map.empty() ||
+        archive->m_slice_status_map[slice.m_file_seq].empty() ||
+        archive->m_slice_status_map[slice.m_file_seq].find(slice.m_slice_seq) ==
+            archive->m_slice_status_map[slice.m_file_seq].end()) {
+      mysql_mutex_unlock(&archive->m_slice_mutex);
+      err_msg.append(" skip deprecated slice when slice status map is empty");
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+             err_msg.c_str());
+      continue;
+    }
+
+    auto &slice_status =
+        archive->m_slice_status_map[slice.m_file_seq][slice.m_slice_seq];
+    err_msg.append(" slice=");
+    err_msg.append(slice_status.archived_info.log_slice_name);
+    err_msg.append(" consensus_end_index=");
+    err_msg.append(std::to_string(
+        slice_status.archived_info.log_slice_end_consensus_index));
+    err_msg.append(" success");
+    if (is_slice_pull) {
+      slice_status.persisted = SLICE_PULL_SUCCESS;
+      slice_status.archived_info.slice_data_cache = slice_data_cache;
+      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+             err_msg.c_str());
+    } else {
+      slice_status.persisted = SLICE_PULL_FAILED;
+      err_msg.append(" failed");
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+             err_msg.c_str());
+      // TODO: If the slice pull failed, set io worker failed.
+      // Binlog archive replica thread will retry.
+    }
+
+    mysql_mutex_unlock(&archive->m_slice_mutex);
+    mysql_cond_signal(&archive->m_map_cond);
+  }
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+         "thread end");
+
+  mysql_mutex_lock(&m_worker_run_lock);
+  delete m_thd;
+  m_thd = nullptr;
+  m_thd_state.set_terminated();
+  mysql_cond_broadcast(&m_worker_run_cond);
+  mysql_mutex_unlock(&m_worker_run_lock);
+  my_thread_end();
+  my_thread_exit(nullptr);
+}
+
+Binlog_archive_replica_relay_worker::Binlog_archive_replica_relay_worker(
+    Binlog_archive_replica *archive)
+    : m_archive(archive),
+      m_thd(nullptr),
+      m_thd_state(),
+      atomic_relay_failed(false),
+      atomic_relay_waiting(true) {
+  mysql_mutex_init(PSI_binlog_archive_replica_relay_worker_lock_key,
+                   &m_worker_run_lock, MY_MUTEX_INIT_FAST);
+  mysql_cond_init(PSI_binlog_archive_replica_relay_worker_cond_key,
+                  &m_worker_run_cond);
+}
+
+Binlog_archive_replica_relay_worker::~Binlog_archive_replica_relay_worker() {
+  stop();
+  mysql_mutex_destroy(&m_worker_run_lock);
+  mysql_cond_destroy(&m_worker_run_cond);
+}
+
+/**
+ * @brief Start the binlog archive worker thread.
+ * @return true if the worker thread was successfully started, false otherwise.
+ */
+bool Binlog_archive_replica_relay_worker::start() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("start"));
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER, "starting");
+  mysql_mutex_lock(&m_worker_run_lock);
+  if (mysql_thread_create(THR_KEY_binlog_archive_replica_relay_worker,
+                          &m_thread, &connection_attrib, thread_launcher,
+                          (void *)this)) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+           "start failed");
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return false;
+  }
+  thread_set_created();
+  while (is_thread_alive_not_running()) {
+    DBUG_PRINT("sleep",
+               ("Waiting for binlog archive replica relay worker to start"));
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_worker_run_cond, &m_worker_run_lock, &abstime);
+  }
+  mysql_mutex_unlock(&m_worker_run_lock);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER, "started");
+  return true;
+}
+
+void Binlog_archive_replica_relay_worker::stop() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("stop"));
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+         "terminate begin");
+  mysql_mutex_lock(&m_worker_run_lock);
+  if (is_thread_dead()) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER, "terminated");
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return;
+  }
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+         "terminating binlog archive replica relay worker");
+  mysql_mutex_unlock(&m_worker_run_lock);
+  terminate_binlog_archive_replica_relay_worker();
+  /* Wait until the thread is terminated. */
+  my_thread_join(&m_thread, nullptr);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER, "terminate end");
+}
+
+/**
+ * @brief Binlog archive thread terminate worker thread.
+ *
+ * @return true if the worker thread was successfully terminated, false
+ * otherwise.
+ */
+int Binlog_archive_replica_relay_worker::
+    terminate_binlog_archive_replica_relay_worker() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("terminate_binlog_archive_replica_relay_worker"));
+  mysql_mutex_lock(&m_worker_run_lock);
+  while (m_thd_state.is_thread_alive()) {
+    DBUG_PRINT("sleep",
+               ("Waiting for binlog archive replica relay worker to stop"));
+    if (m_thd_state.is_initialized()) {
+      mysql_mutex_lock(&m_thd->LOCK_thd_data);
+      m_thd->awake(THD::KILL_CONNECTION);
+      mysql_mutex_unlock(&m_thd->LOCK_thd_data);
+    }
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_worker_run_cond, &m_worker_run_lock, &abstime);
+  }
+  assert(m_thd_state.is_thread_dead());
+  mysql_mutex_unlock(&m_worker_run_lock);
+  return 0;
+}
+
+inline void Binlog_archive_replica_relay_worker::calc_event_checksum(
+    uchar *event_ptr, size_t event_len) {
+  ha_checksum crc = checksum_crc32(0L, nullptr, 0);
+  crc = checksum_crc32(crc, event_ptr, event_len - BINLOG_CHECKSUM_LEN);
+  int4store(event_ptr + event_len - BINLOG_CHECKSUM_LEN, crc);
+}
+
+int Binlog_archive_replica_relay_worker::fake_rotate_event(
+    const char *next_log_file, my_off_t log_pos, ulong server_id,
+    binary_log::enum_binlog_checksum_alg event_checksum_alg,
+    std::string &rotate_buf) {
+  DBUG_TRACE;
+  const char *p = next_log_file + dirname_length(next_log_file);
+  size_t ident_len = strlen(p);
+  size_t event_len =
+      ident_len + LOG_EVENT_HEADER_LEN + Binary_log_event::ROTATE_HEADER_LEN +
+      ((event_checksum_alg > binary_log::BINLOG_CHECKSUM_ALG_OFF &&
+        event_checksum_alg < binary_log::BINLOG_CHECKSUM_ALG_ENUM_END)
+           ? BINLOG_CHECKSUM_LEN
+           : 0);
+  rotate_buf.resize(event_len);
+  uchar *header =
+      reinterpret_cast<uchar *>(const_cast<char *>(rotate_buf.c_str()));
+  uchar *rotate_header = header + LOG_EVENT_HEADER_LEN;
+  /*
+    'when' (the timestamp) is set to 0 so that slave could distinguish between
+    real and fake Rotate events (if necessary)
+  */
+  int4store(header, 0);
+  header[EVENT_TYPE_OFFSET] = binary_log::ROTATE_EVENT;
+  int4store(header + SERVER_ID_OFFSET, server_id);
+  int4store(header + EVENT_LEN_OFFSET, static_cast<uint32>(event_len));
+  int4store(header + LOG_POS_OFFSET, 0);
+  int2store(header + FLAGS_OFFSET, LOG_EVENT_ARTIFICIAL_F);
+
+  int8store(rotate_header, log_pos);
+  memcpy(rotate_header + Binary_log_event::ROTATE_HEADER_LEN, p, ident_len);
+
+  if (event_checksum_alg > binary_log::BINLOG_CHECKSUM_ALG_OFF &&
+      event_checksum_alg < binary_log::BINLOG_CHECKSUM_ALG_ENUM_END)
+    calc_event_checksum(header, event_len);
+
+  return 0;
+}
+
+/**
+ * @brief
+ *
+ * @return void*
+ */
+void *Binlog_archive_replica_relay_worker::worker_thread() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("worker_thread"));
+  Binlog_archive_replica *archive = m_archive;
+
+  m_thd = set_thread_context();
+  mysql_mutex_lock(&m_worker_run_lock);
+  m_thd_state.set_running();
+  mysql_cond_broadcast(&m_worker_run_cond);
+  mysql_mutex_unlock(&m_worker_run_lock);
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+         "thread running");
+
+  while (!unlikely(m_thd->killed)) {
+    std::vector<Slice_pull_status> to_process;
+    std::string err_msg;
+    int error = 0;
+
+    mysql_mutex_lock(&archive->m_slice_mutex);
+    // Wait for the slice to be available.
+    m_thd->ENTER_COND(&archive->m_map_cond, &archive->m_slice_mutex, nullptr,
+                      nullptr);
+    while (((archive->m_slice_status_map.empty() ||
+             (archive->m_slice_status_map.begin())->second.empty() ||
+             (((archive->m_slice_status_map.begin())->second).begin())
+                     ->second.persisted == SLICE_NOT_PULL) &&
+            !unlikely(m_thd->killed))) {
+      // Wait for signal from the binlog archive io thread that the new expected
+      // slice is added to the queue. Or the worker thread is killed.
+      mysql_cond_wait(&archive->m_map_cond, &archive->m_slice_mutex);
+    }
+    if (unlikely(m_thd->killed)) {
+      mysql_mutex_unlock(&archive->m_slice_mutex);
+      m_thd->EXIT_COND(nullptr);
+      break;
+    }
+    mysql_mutex_unlock(&archive->m_slice_mutex);
+    m_thd->EXIT_COND(nullptr);
+
+    mysql_mutex_lock(&archive->m_slice_mutex);
+    // Process from map beginning
+    auto file_it = archive->m_slice_status_map.begin();
+    while (file_it != archive->m_slice_status_map.end()) {
+      auto &slice_map = file_it->second;
+
+      // Process slices from beginning of current file
+      auto slice_it = slice_map.begin();
+      while (slice_it != slice_map.end()) {
+        if (slice_it->second.persisted == SLICE_PULL_FAILED) {
+          err_msg.assign(" binlog slice persisted failed, slice=");
+          err_msg.append(slice_it->second.archived_info.log_slice_name);
+          LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                 err_msg.c_str());
+          set_relay_failed(true);
+          error = 1;
+          break;
+        }
+        if (slice_it->second.persisted == SLICE_NOT_PULL) {
+          // Stop at first non-persisted slice
+          break;
+        }
+        assert(slice_it->second.persisted == SLICE_PULL_SUCCESS);
+        err_msg.assign(" binlog slice persisted, slice=");
+        err_msg.append(slice_it->second.archived_info.log_slice_name);
+        err_msg.append(" persisted slice map file_seq=");
+        err_msg.append(std::to_string(slice_it->second.file_seq));
+        err_msg.append(" slice_seq=");
+        err_msg.append(std::to_string(slice_it->second.slice_seq));
+        LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+               err_msg.c_str());
+        // Add to processing batch
+        to_process.push_back(slice_it->second);
+        slice_it = slice_map.erase(slice_it);
+      }
+
+      if (slice_map.empty()) {
+        // Remove empty file map
+        file_it = archive->m_slice_status_map.erase(file_it);
+      } else {
+        // Stop at first file with remaining slices
+        break;
+      }
+    }
+    mysql_mutex_unlock(&archive->m_slice_mutex);
+
+    // Batch process pulled slices.
+    if (!to_process.empty()) {
+      for (const auto &slice : to_process) {
+        my_off_t reader_size = 0;
+        my_off_t cache_size =
+            slice.archived_info.slice_data_cache.size();  // current slice size.
+        my_off_t end_pos =
+            slice.archived_info
+                .log_slice_end_pos;  // The end position of the binlog where the
+                                     // current slice is located.
+        my_off_t start_read_pos =
+            slice.archived_info
+                .m_start_read_pos;  // The read start position of the binlog
+                                    // where the current slice is located.
+        bool first_slice =
+            slice.archived_info.first_slice;  // Whether the current slice is
+                                              // the first slice of the binlog.
+        // If it is the first slice, the binlog header needs to be skipped
+        // during reading; subsequent slices are read directly from position 0.
+        if (first_slice) {
+          reader_size = BIN_LOG_HEADER_SIZE;
+        }
+        err_msg.assign("relay event from ");
+        err_msg.append(first_slice ? "the first slice " : "the slice ");
+        err_msg.append(slice.archived_info.log_slice_name);
+        err_msg.append(" binlog start_read_pos=");
+        err_msg.append(std::to_string(start_read_pos));
+        err_msg.append(" slice end_pos=");
+        err_msg.append(std::to_string(end_pos));
+        err_msg.append(" slice size=");
+        err_msg.append(std::to_string(cache_size));
+        LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+               err_msg.c_str());
+
+        // Read the slice cache data and send it to the relay log queue.
+        while (likely(reader_size < cache_size)) {
+          const char *event_buf;
+          event_buf =
+              slice.archived_info.slice_data_cache.c_str() + reader_size;
+          Log_event_type type = (Log_event_type)event_buf[EVENT_TYPE_OFFSET];
+          uint32 event_len = uint4korr(event_buf + EVENT_LEN_OFFSET);
+          // uint32 event_pos = uint4korr(event_buf + LOG_POS_OFFSET);
+          DBUG_PRINT(
+              "info",
+              ("binlog archive replica relay thread readed event of type %s",
+               Log_event::get_type_str(type)));
+
+          if (start_read_pos > BIN_LOG_HEADER_SIZE) {
+            if (type == binary_log::FORMAT_DESCRIPTION_EVENT) {
+              assert(first_slice);
+              LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                     "Format_description_log_event found ");
+              // If the starting position for reading the binlog file is in the
+              // middle. Indicates that the first slice of the first binlog file
+              // is read, this is binlog archive replica is running for the
+              // first time. If we are skipping the beginning of the binlog file
+              // based on the position asked by binlog archive replica
+              // "start_read_pos > BIN_LOG_HEADER_SIZE".
+              binary_log::enum_binlog_checksum_alg event_checksum_alg =
+                  Log_event_footer::get_checksum_alg(event_buf, event_len);
+              // We need fake rotate event to set the binlog file name an
+              // position, send to the relay log queue before the format
+              // description event.
+              std::string rotate_buf;
+              fake_rotate_event(slice.archived_info.log_file_name,
+                                start_read_pos,
+                                uint4korr(event_buf + SERVER_ID_OFFSET),
+                                event_checksum_alg, rotate_buf);
+              QUEUE_EVENT_RESULT queue_res = queue_event_from_objstore(
+                  archive->m_master_info, rotate_buf.c_str(),
+                  rotate_buf.length(), true);
+              if (queue_res == QUEUE_EVENT_ERROR_QUEUING) {
+                LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                       "queue Format_description_log_event relay log error");
+                set_relay_failed(true);
+                error = 1;
+                break;
+              }
+
+              // We need to fake the format description event to set the
+              // checksum algorithm to BINLOG_CHECKSUM_ALG_OFF, send to the
+              // relay log queue.
+              uchar *event_ptr =
+                  const_cast<uchar *>(pointer_cast<const uchar *>(event_buf));
+              assert(event_ptr[LOG_POS_OFFSET] > 0);
+              event_ptr[FLAGS_OFFSET] &= ~LOG_EVENT_BINLOG_IN_USE_F;
+              /*
+                If we are skipping the beginning of the binlog file based on the
+                position asked by binlog archive replica "start_read_pos >
+                BIN_LOG_HEADER_SIZE". Mark that this event with "event_pos=0",
+                so the slave should not increment master's binlog position
+                (mi->group_master_log_pos)
+              */
+              int4store(event_ptr + LOG_POS_OFFSET, 0);
+              /*
+                Set the 'created' field to 0 to avoid destroying
+                temp tables on slave.
+              */
+              int4store(
+                  event_ptr + LOG_EVENT_MINIMAL_HEADER_LEN + ST_CREATED_OFFSET,
+                  0);
+              /* fix the checksum due to latest changes in header */
+              if (event_checksum_alg > binary_log::BINLOG_CHECKSUM_ALG_OFF &&
+                  event_checksum_alg < binary_log::BINLOG_CHECKSUM_ALG_ENUM_END)
+                calc_event_checksum(event_ptr, event_len);
+              LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                     "Format_description_log_event fixed ");
+            } else {
+              assert(!first_slice && (end_pos > start_read_pos));
+              // Jump to the start_read_pos position of the slice.
+              reader_size = cache_size - (end_pos - start_read_pos);
+              LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                     "jump to start_read_pos");
+              continue;
+            }
+          }
+
+          DBUG_EXECUTE_IF(
+              "binlog_archive_replica_crash_before_queue_event_relaylog",
+              DBUG_SUICIDE(););
+          QUEUE_EVENT_RESULT queue_res = queue_event_from_objstore(
+              archive->m_master_info, event_buf, event_len, true);
+          if (queue_res == QUEUE_EVENT_ERROR_QUEUING) {
+            LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                   "queue event error");
+            set_relay_failed(true);
+            error = 1;
+            break;
+          }
+          // If the starting position for reading the binlog file is in the
+          // middle, after reading the format_description_log_event, events
+          // before the starting position need to be skipped, and events should
+          // be read starting from the specified start_read_pos position.
+          // This only occurs when reading the first binlog file; subsequent
+          // binlog files are read starting from position BIN_LOG_HEADER_SIZE.
+          if (first_slice && start_read_pos > BIN_LOG_HEADER_SIZE) {
+            // After reading the FORMAT_DESCRIPTION_EVENT of the first slice of
+            // the first binlog, is this slice no longer needed?
+            // This indicates that this slice is only used to read the
+            // FORMAT_DESCRIPTION_EVENT.
+            if (start_read_pos >= end_pos) {
+              // Skip current slice.
+              LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                     "skip current slice");
+              break;
+            } else {
+              assert(cache_size == end_pos);
+              // Jump to the start_read_pos position of the first slice.
+              reader_size = start_read_pos;
+              LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                     "jump to start_read_pos");
+              continue;
+            }
+          }
+          reader_size += event_len;
+        }
+        err_msg.assign("relay position");
+        err_msg.append(archive->m_master_info->get_for_channel_str());
+        err_msg.append(" file=");
+        err_msg.append(archive->m_master_info->get_master_log_name());
+        err_msg.append(" pos=");
+        err_msg.append(
+            std::to_string(archive->m_master_info->get_master_log_pos()));
+        // print the current replication position
+        LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+               err_msg.c_str());
+        if (error) break;
+      }
+    }
+  }
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER, "thread end");
+
+  mysql_mutex_lock(&m_worker_run_lock);
+  delete m_thd;
+  m_thd = nullptr;
+  m_thd_state.set_terminated();
+  mysql_cond_broadcast(&m_worker_run_cond);
+  mysql_mutex_unlock(&m_worker_run_lock);
+  my_thread_end();
+  my_thread_exit(nullptr);
+}
+
+/**
+ * @brief Creates a binlog archive object and starts the binlog archive thread.
+ * @return int 0 if the binlog archive thread was successfully started, 1
+ * otherwise.
+ */
+int start_binlog_archive_replica() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("start_binlog_archive_replica"));
+
+  // Check if the binlog archive replica is enabled.
+  if (!opt_binlog_archive_replica || !opt_serverless) {
+    return 0;
+  }
+
+  // Check if the binlog is enabled.
+  if (!opt_bin_log) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, "need enable binlog mode");
+    return 0;
+  }
+
+  if (!relay_log_recovery) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "need enable relay_log_recovery");
+    return 0;
+  }
+
+  if (!opt_binlog_archive_dir) {
+    opt_binlog_archive_dir = mysql_tmpdir;
+  }
+
+  // Check if the mysql archive path is set.
+  if (opt_binlog_archive_dir == nullptr) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "must set binlog_archive_dir");
+    return 1;
+  }
+
+  MY_STAT d_stat;
+  // Check if opt_binlog_archive_dir exists.
+  if (!my_stat(opt_binlog_archive_dir, &d_stat, MYF(0)) ||
+      !MY_S_ISDIR(d_stat.st_mode) ||
+      my_access(opt_binlog_archive_dir, (F_OK | W_OK))) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "binlog_archive_dir path not exists");
+    return 1;
+  }
+
+  // data home can not include archive directory.
+  if (test_if_data_home_dir(opt_binlog_archive_dir)) {
+    std::string err_msg;
+    err_msg.assign(
+        "binlog_archive_dir is within the current data "
+        "directory: ");
+    err_msg.append(opt_binlog_archive_dir);
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+    return 1;
+  }
+
+  // Check if archive binlog dir exists. If not exists, create it.
+  // This directory is used for the local temporary storage of persisted
+  // binlogs.
+  char tmp_archive_binlog_dir[FN_REFLEN + 1] = {0};
+  strmake(tmp_archive_binlog_dir, opt_binlog_archive_dir,
+          sizeof(tmp_archive_binlog_dir) - BINLOG_ARCHIVE_SUBDIR_LEN - 1);
+  strmake(
+      convert_dirname(tmp_archive_binlog_dir, tmp_archive_binlog_dir, NullS),
+      STRING_WITH_LEN(BINLOG_ARCHIVE_SUBDIR));
+  convert_dirname(tmp_archive_binlog_dir, tmp_archive_binlog_dir, NullS);
+
+  // remove local binlog archive dir and recreate it.
+  if (remove_file(tmp_archive_binlog_dir)) {
+    std::string err_msg;
+    err_msg.assign("error ");
+    err_msg.append(std::to_string(my_errno()));
+    err_msg.append(", failed to remove archive dir ");
+    err_msg.append(tmp_archive_binlog_dir);
+    LogErr(WARNING_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+  }
+  if (my_mkdir(tmp_archive_binlog_dir, 0777, MYF(0))) {
+    std::string err_msg;
+    err_msg.assign("error ");
+    err_msg.append(std::to_string(my_errno()));
+    err_msg.append(", failed to create archive dir ");
+    err_msg.append(tmp_archive_binlog_dir);
+    LogErr(WARNING_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+  }
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "start binlog archive replica");
+
+  // replica binlog from source object store.
+  std::string obj_error_msg;
+  std::string err_msg;
+  std::string_view endpoint(
+      opt_source_objectstore_endpoint
+          ? std::string_view(opt_source_objectstore_endpoint)
+          : "");
+  objstore::ObjectStore *objstore = objstore::create_object_store(
+      std::string_view(opt_source_objectstore_provider),
+      std::string_view(opt_source_objectstore_region),
+      opt_source_objectstore_endpoint ? &endpoint : nullptr,
+      opt_source_objectstore_use_https, obj_error_msg);
+  if (!objstore) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_CREATE_OBJECT_STORE,
+           opt_source_objectstore_provider, opt_source_objectstore_region,
+           std::string(endpoint).c_str(), opt_source_objectstore_bucket,
+           opt_source_objectstore_use_https ? "true" : "false",
+           !obj_error_msg.empty() ? obj_error_msg.c_str() : "");
+    return 1;
+  }
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_CREATE_OBJECT_STORE,
+         opt_source_objectstore_provider, opt_source_objectstore_region,
+         std::string(endpoint).c_str(), opt_source_objectstore_bucket,
+         opt_source_objectstore_use_https ? "true" : "false", "");
+  mysql_binlog_archive_replica.set_objstore(objstore);
+
+  mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+  if (mysql_thread_create(
+          THR_KEY_binlog_archive_replica, &mysql_binlog_archive_replica_pthd,
+          &connection_attrib, mysql_binlog_archive_replica_action,
+          (void *)&mysql_binlog_archive_replica)) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_STARTUP,
+           "Failed to create binlog archive replica thread");
+    mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+    return 1;
+  }
+
+  mysql_binlog_archive_replica.thread_set_created();
+
+  while (mysql_binlog_archive_replica.is_thread_alive_not_running()) {
+    DBUG_PRINT("sleep", ("Waiting for binlog archive replica thread to start"));
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_binlog_archive_replica_run_cond,
+                         &m_binlog_archive_replica_run_lock, &abstime);
+  }
+  mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+  return 0;
+}
+
+/**
+ * @brief stop the binlog archive thread.
+ * @note must stop consistent snapshot thread, before stop the binlog archive
+ * thread. Consistent snapshot thread depends on the binlog archive thread.
+ * @return void
+ */
+void stop_binlog_archive_replica() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("stop_binlog_archive_replica"));
+  if (!opt_binlog_archive_replica || !opt_serverless) return;
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, "terminate begin");
+
+  mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+  if (mysql_binlog_archive_replica.is_thread_dead()) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, "terminated");
+    mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+    return;
+  }
+  mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "terminating binlog archive replica");
+  mysql_binlog_archive_replica.terminate_binlog_archive_replica_thread();
+  /* Wait until the thread is terminated. */
+  my_thread_join(&mysql_binlog_archive_replica_pthd, nullptr);
+  if (mysql_binlog_archive_replica.get_objstore()) {
+    objstore::destroy_object_store(mysql_binlog_archive_replica.get_objstore());
+    mysql_binlog_archive_replica.set_objstore(nullptr);
+  }
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, "terminate end");
+}
+
+/**
+ * @brief Archives the MySQL binlog.
+ * @param arg The binlog archive object.
+ */
+static void *mysql_binlog_archive_replica_action(void *arg) {
+  Binlog_archive_replica *archive = (Binlog_archive_replica *)arg;
+  archive->run();
+  return nullptr;
+}
+
+/**
+ * @brief Constructs a Binlog_archive_replica object.
+ */
+Binlog_archive_replica::Binlog_archive_replica()
+    : m_expected_slice_queue(),
+      m_slice_status_map(),
+      m_thd(nullptr),
+      m_thd_state(),
+      m_description_event(BINLOG_VERSION, ::server_version),
+      binlog_objstore(nullptr),
+      m_index_file() {
+  m_mysql_archive_dir[0] = '\0';
+  m_mysql_binlog_archive_dir[0] = '\0';
+  m_binlog_archive_dir[0] = '\0';
+  m_index_local_file_name[0] = '\0';
+  m_relay_worker = nullptr;
+  m_workers = nullptr;
+  m_start_binlog_file[0] = '\0';
+  m_start_binlog_pos = 0;
+}
+
+/**
+ * @brief Destructs the Binlog_archive_replica object.
+ */
+Binlog_archive_replica::~Binlog_archive_replica() {}
+
+/**
+ * @brief Initializes the binlog archive object.
+ */
+void Binlog_archive_replica::init_pthread_object() {
+#ifdef HAVE_PSI_INTERFACE
+  const char *category = "archive";
+  int count_thread =
+      static_cast<int>(array_elements(all_binlog_archive_threads));
+  mysql_thread_register(category, all_binlog_archive_threads, count_thread);
+
+  int count_mutex =
+      static_cast<int>(array_elements(all_binlog_archive_mutex_info));
+  mysql_mutex_register(category, all_binlog_archive_mutex_info, count_mutex);
+
+  int count_cond =
+      static_cast<int>(array_elements(all_binlog_archive_cond_info));
+  mysql_cond_register(category, all_binlog_archive_cond_info, count_cond);
+
+  int count_file = static_cast<int>(array_elements(all_binlog_archive_files));
+  mysql_file_register(category, all_binlog_archive_files, count_file);
+
+#endif
+
+  mysql_cond_init(PSI_binlog_archive_replica_cond_key,
+                  &m_binlog_archive_replica_run_cond);
+  mysql_mutex_init(PSI_binlog_archive_replica_lock_key,
+                   &m_binlog_archive_replica_run_lock, MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(PSI_binlog_index_lock_key, &m_index_lock,
+                   MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(PSI_binlog_slice_lock_key, &m_slice_mutex,
+                   MY_MUTEX_INIT_FAST);
+  mysql_cond_init(PSI_binlog_slice_queue_cond_key, &m_queue_cond);
+  mysql_cond_init(PSI_binlog_slice_map_cond_key, &m_map_cond);
+}
+
+/**
+ * @brief Cleans up any resources used by the binlog archive.
+ */
+void Binlog_archive_replica::deinit_pthread_object() {
+  mysql_cond_destroy(&m_map_cond);
+  mysql_cond_destroy(&m_queue_cond);
+  mysql_mutex_destroy(&m_slice_mutex);
+  mysql_mutex_destroy(&m_index_lock);
+  mysql_mutex_destroy(&m_binlog_archive_replica_run_lock);
+  mysql_cond_destroy(&m_binlog_archive_replica_run_cond);
+}
+
+/**
+ * @brief Returns the binlog archive instance.
+ * @return Binlog_archive_replica*
+ */
+Binlog_archive_replica *Binlog_archive_replica::get_instance() {
+  return &mysql_binlog_archive_replica;
+}
+
+/**
+ * @brief Returns the binlog archive lock.
+ *
+ * @return mysql_mutex_t*
+ */
+mysql_mutex_t *Binlog_archive_replica::get_binlog_archive_lock() {
+  return &m_binlog_archive_replica_run_lock;
+}
+
+/**
+ * @brief Terminate the binlog archive thread.
+ *
+ * @return int
+ */
+int Binlog_archive_replica::terminate_binlog_archive_replica_thread() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("terminate_binlog_archive_replica_thread"));
+  mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+  while (m_thd_state.is_thread_alive()) {
+    DBUG_PRINT("sleep", ("Waiting for binlog archive replica thread to stop"));
+    if (m_thd_state.is_initialized()) {
+      mysql_mutex_lock(&m_thd->LOCK_thd_data);
+      m_thd->awake(THD::KILL_CONNECTION);
+      mysql_mutex_unlock(&m_thd->LOCK_thd_data);
+    }
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_cond_timedwait(&m_binlog_archive_replica_run_cond,
+                         &m_binlog_archive_replica_run_lock, &abstime);
+  }
+  assert(m_thd_state.is_thread_dead());
+  mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+  return 0;
+}
+
+/**
+ * @brief Initializes the THD context.
+ *
+ */
+static THD *set_thread_context() {
+  THD *thd = new THD;
+  my_thread_init();
+  thd->set_new_thread_id();
+  thd->thread_stack = (char *)&thd;
+  thd->store_globals();
+  thd->get_protocol_classic()->init_net(nullptr);
+  thd->system_thread = SYSTEM_THREAD_BACKGROUND;
+  /* No privilege check needed */
+  thd->security_context()->skip_grants();
+  // Global_THD_manager::get_instance()->add_thd(thd);
+  return thd;
+}
+
+/**
+ * @brief Runs the binlog archive replica process.
+ */
+void Binlog_archive_replica::run() {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("Binlog_archive_replica::run"));
+  std::string err_msg{};
+  int error = 0;
+  bool first_run = true;
+
+  m_thd = set_thread_context();
+
+  mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+  m_thd_state.set_initialized();
+  mysql_cond_broadcast(&m_binlog_archive_replica_run_cond);
+  mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+
+  strmake(m_mysql_archive_dir, opt_binlog_archive_dir,
+          sizeof(m_mysql_archive_dir) - 1);
+  convert_dirname(m_mysql_archive_dir, m_mysql_archive_dir, NullS);
+  strmake(strmake(m_mysql_binlog_archive_dir, m_mysql_archive_dir,
+                  sizeof(m_mysql_binlog_archive_dir) -
+                      BINLOG_ARCHIVE_SUBDIR_LEN - 1),
+          STRING_WITH_LEN(BINLOG_ARCHIVE_SUBDIR));
+  // if m_binlog_archive_dir dir not exists, start_binlog_archive() will create
+  // it.
+  convert_dirname(m_mysql_binlog_archive_dir, m_mysql_binlog_archive_dir,
+                  NullS);
+
+  // Binlog archive replica source object directory prefix.
+  std::string binlog_objectstore_path(opt_source_objectstore_repo_id);
+  binlog_objectstore_path.append(FN_DIRSEP);
+  binlog_objectstore_path.append(opt_source_objectstore_branch_id);
+  binlog_objectstore_path.append(FN_DIRSEP);
+  binlog_objectstore_path.append(BINLOG_ARCHIVE_SUBDIR);
+  binlog_objectstore_path.append(FN_DIRSEP);
+  strmake(m_binlog_archive_dir, binlog_objectstore_path.c_str(),
+          sizeof(m_binlog_archive_dir) - 1);
+
+  mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+  m_thd_state.set_running();
+  mysql_cond_broadcast(&m_binlog_archive_replica_run_cond);
+  mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+  err_msg.assign("Binlog archive replica thread running");
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+
+  // init binlog archive replica slice queue.
+  assert(!m_expected_slice_queue.inited_queue);
+  m_expected_slice_queue.avail = 0;
+  m_expected_slice_queue.entry = 0;
+  m_expected_slice_queue.len = 0;
+  m_expected_slice_queue.capacity = 4 * opt_binlog_archive_parallel_workers;
+  m_expected_slice_queue.inited_queue = true;
+  Binlog_expected_pull_slice slice;
+  m_expected_slice_queue.m_Q.resize(m_expected_slice_queue.capacity, slice);
+  assert(m_expected_slice_queue.m_Q.size() == m_expected_slice_queue.capacity);
+
+  // Create new binlog archive replica channel, if not exists.
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "create binlog archive replica channel");
+  channel_create();
+
+  // create binlog archive replica relay worker.
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "create binlog archive replica relay worker");
+  m_relay_worker = new Binlog_archive_replica_relay_worker(this);
+  if (!m_relay_worker->start()) goto end;
+
+  // create binlog archive replica io worker thread.
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "create binlog archive replica io worker");
+  m_workers = static_cast<Binlog_archive_replica_io_worker **>(
+      my_malloc(PSI_NOT_INSTRUMENTED,
+                opt_binlog_archive_parallel_workers *
+                    sizeof(Binlog_archive_replica_io_worker *),
+                MYF(MY_WME)));
+  if (!m_workers) goto end;
+  for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
+    Binlog_archive_replica_io_worker *worker =
+        new Binlog_archive_replica_io_worker(this, i);
+    m_workers[i] = worker;
+    if (!worker->start()) goto end;
+  }
+
+  m_last_expected_file_seq = 0;
+  m_last_expected_slice_seq = 0;
+  for (;;) {
+    error = 0;
+    mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+    if (m_thd == nullptr || unlikely(m_thd->killed)) {
+      err_msg.assign("killed");
+      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+      mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+      break;
+    }
+    mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+
+#ifdef WESQL_CLUSTER
+    // Check whether consensus role is leader
+    uint64_t consensus_term = 0;
+    // Check whether consensus role is leader and fetch leader term
+    if (DBUG_EVALUATE_IF("fault_injection_binlog_archive_running", true,
+                         false) ||
+        !is_consensus_replication_state_leader(consensus_term)) {
+      struct timespec abstime;
+      set_timespec(&abstime, 1);
+      mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+      error =
+          mysql_cond_timedwait(&m_binlog_archive_replica_run_cond,
+                               &m_binlog_archive_replica_run_lock, &abstime);
+      mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+      continue;
+    }
+#endif
+    // Startup applier thread.
+    if (!channel_is_running() && (error = channel_start())) {
+      err_msg.assign(
+          "failed to start binlog archive replica applier sql thread");
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+      break;
+    }
+
+    LOG_ARCHIVED_INFO log_info{};
+    mysql_mutex_lock(&m_index_lock);
+    // open persistent binlog.index from source object storage.
+    // Fetch the latest binlog index from the source object storage.
+    if (open_index_file()) {
+      mysql_mutex_unlock(&m_index_lock);
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+             "failed to open source binlog index file");
+      goto end;
+    }
+    if (!first_run && m_start_binlog_file[0] != '\0') {
+      my_off_t last_slice_end_pos;
+      bool next_log = false;
+      bool binlog_updated = false;
+      err_msg.assign("Find binlog from persistent binlog index, binlog=");
+      err_msg.append(m_start_binlog_file);
+      err_msg.append(" pos=");
+      err_msg.append(std::to_string(m_start_binlog_pos));
+      // Find more binlog slice replication from source persistent
+      // binlog.index.
+      error = find_log_pos_by_name(&log_info, m_start_binlog_file);
+      if (error == 0) {
+        do {
+          last_slice_end_pos = log_info.slice_end_pos;
+          if (next_log || m_start_binlog_pos < last_slice_end_pos) {
+            // Already more binlog slice need replica.
+            binlog_updated = true;
+            break;
+          }
+        } while (!(error = find_next_log_slice(&log_info, next_log)));
+        if (error != LOG_INFO_IO && !binlog_updated) {
+          if (m_start_binlog_pos == last_slice_end_pos) {
+            close_index_file();
+            mysql_mutex_unlock(&m_index_lock);
+            // If no more binlog slice to pull in source object store, retry
+            // after 1 second.
+            struct timespec abstime;
+            set_timespec(&abstime, 1);
+            mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+            error = mysql_cond_timedwait(&m_binlog_archive_replica_run_cond,
+                                         &m_binlog_archive_replica_run_lock,
+                                         &abstime);
+            mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+            continue;
+          } else {
+            error = 1;
+          }
+        }
+      }
+      if (error) {
+        close_index_file();
+        mysql_mutex_unlock(&m_index_lock);
+        err_msg.append(", not found");
+        LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+        goto end;
+      }
+    }
+
+    // Init start binlog file and position.
+    if (m_start_binlog_file[0] == '\0' &&
+        m_master_info->get_master_log_name() &&
+        m_master_info->get_master_log_name()[0] != '\0') {
+      strmake(m_start_binlog_file, m_master_info->get_master_log_name(),
+              sizeof(m_start_binlog_file) - 1);
+      m_start_binlog_pos = m_master_info->get_master_log_pos();
+      err_msg.assign("init persistent binlog replica start_binlog_file=");
+      err_msg.append(m_start_binlog_file);
+      err_msg.append(" star_pos=");
+      err_msg.append(std::to_string(m_start_binlog_pos));
+      LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+    }
+    // Find start binlog file from the persistent binlog index.
+    if (!(error = find_log_pos_by_name(&log_info, m_start_binlog_file))) {
+      bool next_log = false;
+      if (m_start_binlog_file[0] == '\0') {
+        // Start from the first binlog file in the binlog.index.
+        mysql_mutex_lock(&m_master_info->data_lock);
+        m_master_info->set_master_log_name(log_info.log_file_name);
+        m_master_info->set_master_log_pos(BIN_LOG_HEADER_SIZE);
+        mysql_mutex_unlock(&m_master_info->data_lock);
+        strmake(m_start_binlog_file, log_info.log_file_name,
+                sizeof(m_start_binlog_file) - 1);
+        m_start_binlog_pos = BIN_LOG_HEADER_SIZE;
+        err_msg.assign("init persistent binlog replica start_binlog_file=");
+        err_msg.append(m_start_binlog_file);
+        err_msg.append(" star_pos=");
+        err_msg.append(std::to_string(m_start_binlog_pos));
+        LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+      }
+      // If startup on the first time, read format_description_event from
+      // the the first binlog slice in start_binlog_file.
+      if (first_run) {
+        err_msg.assign(
+            " when first running, read expected the first slice key from "
+            "index ");
+        err_msg.append(m_start_binlog_file);
+        err_msg.append(" start_pos=");
+        err_msg.append(std::to_string(m_start_binlog_pos));
+        LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+        if (!add_slice(log_info, true, m_start_binlog_pos)) {
+          close_index_file();
+          mysql_mutex_unlock(&m_index_lock);
+          err_msg.append("failed");
+          LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+          goto end;
+        }
+        first_run = false;
+      }
+
+      // Get next binlig slice.
+      while (!(error = find_next_log_slice(&log_info, next_log))) {
+        // Skip binlog slice if the end position is less equal than the start
+        if (!next_log && log_info.slice_end_pos <= m_start_binlog_pos) {
+          continue;
+        }
+        // If the next log slice is not the same as the previous log slice,
+        // read the format description event from the next log slice.
+        err_msg.assign(" read expected binlog slice key from index ");
+        err_msg.append(log_info.log_file_name);
+        err_msg.append(" start_pos=");
+        err_msg.append(std::to_string(log_info.slice_end_pos));
+        if (!add_slice(log_info, next_log, BIN_LOG_HEADER_SIZE)) {
+          close_index_file();
+          mysql_mutex_unlock(&m_index_lock);
+          err_msg.append("failed");
+          LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+          goto end;
+        }
+        // Update the start binlog file and position.
+        if (next_log) {
+          strmake(m_start_binlog_file, log_info.log_file_name,
+                  sizeof(m_start_binlog_file) - 1);
+        }
+        m_start_binlog_pos = log_info.slice_end_pos;
+        LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+      }
+    }
+    close_index_file();
+    mysql_mutex_unlock(&m_index_lock);
+    if (error == LOG_INFO_IO) {
+      err_msg.assign("failed to read binlog index file");
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+      break;
+    }
+  }
+
+end:
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "stopping binlog archive replica index worker");
+  if (m_relay_worker) {
+    delete m_relay_worker;
+    m_relay_worker = nullptr;
+  }
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "stopping binlog archive replica io worker");
+  for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
+    Binlog_archive_replica_io_worker *worker = m_workers[i];
+    delete worker;
+  }
+  if (m_workers) {
+    my_free(m_workers);
+    m_workers = nullptr;
+  }
+
+  channel_stop();
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "binlog archive replica thread end");
+  m_thd->clear_error();
+  m_thd->release_resources();
+  mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+  delete m_thd;
+  m_thd = nullptr;
+  m_thd_state.set_terminated();
+  mysql_cond_broadcast(&m_binlog_archive_replica_run_cond);
+  mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+  my_thread_end();
+  my_thread_exit(nullptr);
+}
+
+/**
+ * @brief Add a slice to the expected slice queue.
+ *
+ * @param slice
+ */
+bool Binlog_archive_replica::add_slice(LOG_ARCHIVED_INFO &log_info,
+                                       bool first_slice,
+                                       my_off_t start_read_pos) {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("add_slice"));
+  std::string err_msg;
+  std::string binlog_slice_key;
+  binlog_slice_key.assign(m_binlog_archive_dir);
+  binlog_slice_key.append(log_info.log_slice_name);
+  // write slice key to m_expected_slice_queue
+  Binlog_expected_pull_slice expected_slice(binlog_slice_key.c_str(),
+                                            m_last_expected_file_seq,
+                                            m_last_expected_slice_seq++);
+  SLICE_PULL_INFO slice_info;
+  strmake(slice_info.log_file_name, log_info.log_file_name,
+          sizeof(slice_info.log_file_name) - 1);
+  strmake(slice_info.log_slice_name, binlog_slice_key.c_str(),
+          sizeof(slice_info.log_slice_name) - 1);
+  slice_info.log_slice_end_consensus_index = log_info.slice_end_consensus_index;
+  slice_info.log_slice_previous_consensus_index =
+      log_info.log_previous_consensus_index;
+  slice_info.log_slice_consensus_term = log_info.slice_consensus_term;
+  slice_info.log_slice_end_pos = log_info.slice_end_pos;
+  slice_info.first_slice = first_slice;
+  slice_info.m_start_read_pos = start_read_pos;
+
+  err_msg.assign("add slice key to expected slice queue ");
+  err_msg.append("file_seq=");
+  err_msg.append(std::to_string(expected_slice.m_file_seq));
+  err_msg.append(" slice_seq=");
+  err_msg.append(std::to_string(expected_slice.m_slice_seq));
+  err_msg.append(" log_slice_keyid=");
+  err_msg.append(expected_slice.m_slice_keyid);
+  err_msg.append(" log_slice_name=");
+  err_msg.append(slice_info.log_slice_name);
+  err_msg.append(" consensus_end_index=");
+  err_msg.append(std::to_string(slice_info.log_slice_end_consensus_index));
+  err_msg.append(" previous_consensus_index=");
+  err_msg.append(std::to_string(slice_info.log_slice_previous_consensus_index));
+  err_msg.append(" end_pos=");
+  err_msg.append(std::to_string(slice_info.log_slice_end_pos));
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+
+  DBUG_EXECUTE_IF("fault_injection_add_slice_queue", {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
+           "fault_injection_add_slice_queue");
+    return false;
+  });
+
+  mysql_mutex_lock(&m_slice_mutex);
+  m_thd->ENTER_COND(&m_queue_cond, &m_slice_mutex, nullptr, nullptr);
+  while (m_expected_slice_queue.full() && !m_thd->killed) {
+    // Wait for signal from the binlog archive worker thread that the slice
+    // is persisted and dequeued from the expected slice queue.
+    // Or binlog archive thread is killed.
+    mysql_cond_wait(&m_queue_cond, &m_slice_mutex);
+  }
+  m_expected_slice_queue.en_queue(&expected_slice);
+  m_slice_status_map[expected_slice.m_file_seq][expected_slice.m_slice_seq] =
+      Slice_pull_status(expected_slice.m_file_seq, expected_slice.m_slice_seq,
+                        slice_info);
+  mysql_mutex_unlock(&m_slice_mutex);
+  m_thd->EXIT_COND(nullptr);
+  if (m_thd->killed) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, " thread killed");
+    return false;
+  }
+  // Signal the binlog archive worker thread that wait, because the slice
+  // queue is empty.
+  mysql_cond_signal(&m_queue_cond);
+  return true;
+}
+
+/**
+ * @brief Fetch persistent objects from the object store by the search key.
+ *
+ * @param persistent_objects result of the fetched objects.
+ * @param search_key search key.
+ * @param all whether to fetch all objects, otherwise fetch one page.
+ * @param allow_no_search_key whether to allow no search key.
+ * @return true if the fetch is successful; otherwise, false.
+ */
+bool Binlog_archive_replica::list_persistent_objects(
+    std::vector<objstore::ObjectMeta> &persistent_objects,
+    const char *search_key, bool all, bool allow_no_search_key) {
+  DBUG_TRACE;
+  DBUG_PRINT("info", ("list_persistent_objects"));
+  bool finished = false;
+  std::string start_after;
+  std::string binlog_index_prefix;
+  binlog_index_prefix.assign(m_binlog_archive_dir);
+  binlog_index_prefix.append(search_key);
+  do {
+    std::vector<objstore::ObjectMeta> tmp_objects;
+    objstore::Status ss = binlog_objstore->list_object(
+        std::string_view(opt_source_objectstore_bucket), binlog_index_prefix,
+        false, start_after, finished, tmp_objects);
+    if (!ss.is_succ()) {
+      if (allow_no_search_key &&
+          ss.error_code() == objstore::Errors::SE_NO_SUCH_KEY) {
+        return true;
+      }
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LIST_OBJECT, "failed",
+             binlog_index_prefix.c_str(),
+             std::string(ss.error_message()).c_str());
+      return false;
+    }
+    persistent_objects.insert(persistent_objects.end(), tmp_objects.begin(),
+                              tmp_objects.end());
+  } while (all == true && finished == false);
+  // sort the objects by key in lexicographical order.
+  std::sort(persistent_objects.begin(), persistent_objects.end(),
+            [](const objstore::ObjectMeta &a, const objstore::ObjectMeta &b) {
+              return a.key < b.key;
+            });
+  if (allow_no_search_key == false && persistent_objects.empty()) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LIST_OBJECT, "failed",
+           binlog_index_prefix.c_str(), "no persistent objects found");
+    return false;
+  }
+  DBUG_PRINT("info", ("list binlog index  %s", binlog_index_prefix.c_str()));
+  return true;
+}
+
+/**
+ * @brief Get the last persistent binlog index file.
+ * The persisted `binlog-index.index` is based on multiple versions of the
+ * consensus term, so the `binlog-index.index` with the highest consensus term
+ * should be obtained as the initial one.
+ * @param last_binlog_index
+ * @return int
+ */
+int Binlog_archive_replica::fetch_last_persistent_index_file(
+    std::string &last_binlog_index) {
+  std::vector<objstore::ObjectMeta> objects;
+
+  if (!list_persistent_objects(objects, BINLOG_ARCHIVE_INDEX_FILE_BASENAME,
+                               true, false)) {
+    return 1;
+  }
+  // if no persistent binlog.index, return.
+  if (objects.empty()) {
+    DBUG_PRINT("info", ("no persistent binlog index file %s",
+                        BINLOG_ARCHIVE_INDEX_FILE_BASENAME));
+    return 0;
+  }
+  last_binlog_index.assign((objects.back()).key);
+  DBUG_PRINT("info", ("the last persistent binlog index is %s",
+                      last_binlog_index.c_str()));
+  return 0;
+}
+
+/**
+ * @brief  Open the binlog archive index file.
+ *
+ * @note  Mutex be called with m_index_lock held.
+ * @return true, if error
+ * @return false, if success
+ */
+bool Binlog_archive_replica::open_index_file() {
+  bool error = false;
+  File index_file_nr = -1;
+  std::string last_binlog_index_keyid{};
+
+  /*
+    First open of this class instance
+    Create an index file that will hold all file names uses for logging.
+    Add new entries to the end of it.
+  */
+  myf opt = MY_UNPACK_FILENAME | MY_REPLACE_DIR;
+
+  if (my_b_inited(&m_index_file)) goto end;
+
+  fn_format(m_index_local_file_name, BINLOG_ARCHIVE_REPLICA_INDEX_LOCAL_FILE,
+            m_mysql_binlog_archive_dir, ".index", opt);
+
+  // Check if the index file exists in s3, if so, download it to local.
+  // Problem: If a new index file is generated while retrieving the last index
+  // file through list_object(), the slice index obtained from reading the
+  // index may not be the one that actually needs to be read. Instead, it
+  // could be a slice produced by the old leader, which might conflict with
+  // slices generated by the new leader. If events are relayed in this
+  // scenario, it could lead to data inconsistency.
+  // Solution: After obtaining the latest index through get_object(), perform
+  // another list_object() call to fetch the latest index again and check if it
+  // matches the index already retrieved. If they are consistent, the slices
+  // within the index can be used (ensuring the currently read index is the
+  // latest file and its slices are valid). Otherwise, the index needs to be
+  // re-read.
+  while (true) {
+    if (fetch_last_persistent_index_file(last_binlog_index_keyid)) {
+      return true;
+    }
+    assert(!last_binlog_index_keyid.empty());
+    auto status = binlog_objstore->get_object_to_file(
+        std::string_view(opt_source_objectstore_bucket),
+        last_binlog_index_keyid, std::string_view(m_index_local_file_name));
+    if (!status.is_succ()) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_GET_OBJECT_TO_FILE,
+             "get last persistent binlog-index.index failed",
+             last_binlog_index_keyid.c_str(), m_index_local_file_name,
+             std::string(status.error_message()).c_str());
+      return true;
+    }
+    std::string last_binlog_index_keyid_retry{};
+    if (fetch_last_persistent_index_file(last_binlog_index_keyid_retry)) {
+      return true;
+    }
+    if (last_binlog_index_keyid.compare(last_binlog_index_keyid_retry) == 0) {
+      break;
+    }
+    mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+    if (m_thd == nullptr || unlikely(m_thd->killed)) {
+      std::string err_msg;
+      err_msg.assign("run exit, persist end consensus index=");
+      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+      mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+      return true;
+    }
+    mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+    struct timespec abstime;
+    set_timespec(&abstime, 1);
+    mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+    error = mysql_cond_timedwait(&m_binlog_archive_replica_run_cond,
+                                 &m_binlog_archive_replica_run_lock, &abstime);
+    mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+  }
+  if (my_chmod(m_index_local_file_name,
+               USER_READ | USER_WRITE | GROUP_READ | GROUP_WRITE | OTHERS_READ,
+               MYF(0))) {
+    std::string err_msg;
+    err_msg.assign("Failed to chmod: ");
+    err_msg.append(m_index_local_file_name);
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX, err_msg.c_str());
+    error = true;
+    goto end;
+  }
+  DBUG_PRINT("info",
+             ("get last persistent binlog-index.index %s %s",
+              last_binlog_index_keyid.c_str(), m_index_local_file_name));
+
+  if ((index_file_nr = mysql_file_open(PSI_binlog_archive_log_index_key,
+                                       m_index_local_file_name,
+                                       O_RDWR | O_CREAT, MYF(MY_WME))) < 0 ||
+      mysql_file_sync(index_file_nr, MYF(MY_WME)) ||
+      init_io_cache_ext(&m_index_file, index_file_nr, IO_SIZE, READ_CACHE,
+                        mysql_file_seek(index_file_nr, 0L, MY_SEEK_END, MYF(0)),
+                        false, MYF(MY_WME | MY_WAIT_IF_FULL),
+                        PSI_binlog_archive_log_index_cache_key)) {
+    if (index_file_nr >= 0) {
+      mysql_file_close(index_file_nr, MYF(0));
+    }
+    error = true;
+    goto end;
+  }
+
+end:
+  return error;
+}
+
+/**
+ * @brief Closes the binlog archive index file.
+ * @note
+ *  Mutex needed because we need to make sure the file pointer does not move
+    from under our feet
+ * @return int
+ */
+void Binlog_archive_replica::close_index_file() {
+  DBUG_TRACE;
+  if (my_b_inited(&m_index_file)) {
+    end_io_cache(&m_index_file);
+    if (mysql_file_close(m_index_file.file, MYF(0)))
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+             "Failed to close binlog index file");
+  }
+}
+
+/**
+  Find the position in the log-index-file for the given log name.
+
+  @param[out] linfo The found log file name will be stored here, along
+  with the byte offset of the next log file name in the index file.
+  @param log_name Filename to find in the index file, or NULL if we
+  want to read the first entry.
+  @param need_lock_index If false, this function acquires m_index_lock;
+  otherwise the lock should already be held by the caller.
+
+  @note
+    On systems without the truncate function the file will end with one or
+    more empty lines.  These will be ignored when reading the file.
+
+  @retval
+    0			ok
+  @retval
+    LOG_INFO_EOF	        End of log-index-file found
+  @retval
+    LOG_INFO_IO		Got IO error while reading file
+*/
+int Binlog_archive_replica::find_log_pos_common(
+    IO_CACHE *index_file, LOG_ARCHIVED_INFO *linfo, const char *log_name,
+    uint64_t consensus_index, bool last_slice [[maybe_unused]]) {
+  DBUG_TRACE;
+  int error = 0;
+
+  /* As the file is flushed, we can't get an error here */
+  my_b_seek(index_file, (my_off_t)0);
+
+  for (;;) {
+    size_t length = 0;
+    my_off_t offset = my_b_tell(index_file);
+
+    /* If we get 0 or 1 characters, this is the end of the file */
+    if ((length = my_b_gets(index_file, linfo->log_line, FN_REFLEN)) <= 1) {
+      /* Did not find the given entry; Return not found or error */
+      error = !index_file->error ? LOG_INFO_EOF : LOG_INFO_IO;
+      break;
+    }
+    /* Get rid of the trailing '\n' */
+    linfo->log_line[length - 1] = 0;
+
+    /*
+      {$binlog_file_name}.{$consensus_term}.{$slice_end_pos}|{$end_index}|{$previous_index}
+
+      binlog.000001.00000000000000000000.0000000377|0
+      binlog.000002.00000000000000000000.0000000295|1
+      binlog.000003.00000000000000000000.0000000295|1
+      binlog.000004.00000000000000000000.0000001924|1
+      binlog.000004.00000000000000000000.0000014524|1
+      binlog.000004.00000000000000000000.0000025541|1
+      binlog.000005.00000000000000000000.0000000291|11
+      binlog.000005.00000000000000000000.0000000429|11
+    */
+    std::string in_str;
+    in_str.assign(linfo->log_line);
+    size_t idx = in_str.find("|");
+    std::string found_log_slice_name = in_str.substr(0, idx);
+    std::string left_string = in_str.substr(idx + 1);
+    idx = left_string.find("|");
+    std::string found_end_consensus_index = left_string.substr(0, idx);
+    linfo->slice_end_consensus_index = std::stoull(found_end_consensus_index);
+    std::string found_previous_consensus_index = left_string.substr(idx + 1);
+    linfo->log_previous_consensus_index =
+        std::stoull(found_previous_consensus_index);
+
+    strmake(linfo->log_slice_name, found_log_slice_name.c_str(),
+            sizeof(linfo->log_slice_name) - 1);
+
+    size_t first_dot = found_log_slice_name.find('.');
+    if (first_dot == std::string::npos) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+             "Invalid log slice index entry", found_log_slice_name);
+      error = LOG_INFO_IO;
+      break;
+    }
+    size_t second_dot = found_log_slice_name.find('.', first_dot + 1);
+    if (second_dot == std::string::npos) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+             "Invalid log slice index entry", found_log_slice_name);
+      error = LOG_INFO_IO;
+      break;
+    }
+    std::string file_name = found_log_slice_name.substr(0, second_dot);
+
+    strmake(linfo->log_file_name, file_name.c_str(),
+            sizeof(linfo->log_file_name) - 1);
+
+    left_string = found_log_slice_name.substr(second_dot + 1);
+    size_t third_dot = left_string.find('.');
+    if (third_dot == std::string::npos) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+             "Invalid log slice index entry", found_log_slice_name);
+      error = LOG_INFO_IO;
+      break;
+    }
+    std::string term = left_string.substr(0, third_dot);
+    linfo->slice_consensus_term = std::stoull(term);
+    std::string end_pos = left_string.substr(third_dot + 1);
+    linfo->slice_end_pos = std::stoull(end_pos);
+
+    // if the log entry matches, null string matching anything
+    if (!log_name || log_name[0] == '\0' ||
+        !compare_log_name(file_name.c_str(), log_name)) {
+      if (consensus_index == 0 ||
+          consensus_index == linfo->log_previous_consensus_index) {
+        DBUG_PRINT("info", ("Found log file entry"));
+        linfo->index_file_start_offset = offset;
+        linfo->index_file_offset = my_b_tell(index_file);
+        break;
+      }
+    }
+    linfo->entry_index++;
+  }
+
+  return error;
+}
+
+int Binlog_archive_replica::find_log_pos_by_name(LOG_ARCHIVED_INFO *linfo,
+                                                 const char *log_name) {
+  DBUG_TRACE;
+
+  if (!my_b_inited(&m_index_file)) {
+    return LOG_INFO_IO;
+  }
+  return find_log_pos_common(&m_index_file, linfo, log_name, 0);
+}
+
+/**
+ * @brief Find the position in the log-index-file for the given log name.
+
+  @param[out] linfo The filename will be stored here, along with the
+  byte offset of the next filename in the index file.
+
+  @param need_lock_index If true, m_index_lock will be acquired;
+  otherwise it should already be held by the caller.
+
+  @note
+    - Before calling this function, one has to call find_log_pos()
+    to set up 'linfo'
+    - Mutex needed because we need to make sure the file pointer does not move
+    from under our feet
+
+  @retval 0 ok
+  @retval LOG_INFO_EOF End of log-index-file found
+  @retval LOG_INFO_IO Got IO error while reading file
+*/
+int Binlog_archive_replica::find_next_log(LOG_ARCHIVED_INFO *linfo) {
+  DBUG_TRACE;
+  bool next_log = false;
+
+  if (!my_b_inited(&m_index_file)) {
+    return LOG_INFO_IO;
+  }
+  return find_next_log_common(&m_index_file, linfo, next_log, false);
+}
+
+/**
+ * @brief
+ *
+ * @param index_file
+ * @param linfo
+ * @param found_slice
+ * @param next_log true if the next log file is found.
+ * @return int
+ */
+int Binlog_archive_replica::find_next_log_common(IO_CACHE *index_file,
+                                                 LOG_ARCHIVED_INFO *linfo,
+                                                 bool &next_log,
+                                                 bool found_slice) {
+  DBUG_TRACE;
+  int error = 0;
+  size_t length = 0;
+  std::string previous_log_name;
+  previous_log_name.assign(linfo->log_file_name);
+  next_log = false;
+
+  if (!my_b_inited(index_file)) {
+    error = LOG_INFO_IO;
+    return error;
+  }
+  /* As the file is flushed, we can't get an error here */
+  my_b_seek(index_file, linfo->index_file_offset);
+
+  for (;;) {
+    linfo->index_file_start_offset = linfo->index_file_offset;
+    if ((length = my_b_gets(index_file, linfo->log_line, FN_REFLEN)) <= 1) {
+      error = !index_file->error ? LOG_INFO_EOF : LOG_INFO_IO;
+      break;
+    }
+
+    /* Get rid of the trailing '\n' */
+    linfo->log_line[length - 1] = 0;
+
+    // {$binlog_file_name}.{$consensus_term}.{$slice_end_pos}|{$previouse_index}
+    // binlog.000010.00000000000000001120.0000000512|454
+    std::string in_str;
+    in_str.assign(linfo->log_line);
+    size_t idx = in_str.find("|");
+    std::string found_log_slice_name = in_str.substr(0, idx);
+    std::string left_string = in_str.substr(idx + 1);
+    idx = left_string.find("|");
+    std::string found_end_consensus_index = left_string.substr(0, idx);
+    linfo->slice_end_consensus_index = std::stoull(found_end_consensus_index);
+    std::string found_previous_consensus_index = left_string.substr(idx + 1);
+    linfo->log_previous_consensus_index =
+        std::stoull(found_previous_consensus_index);
+
+    strmake(linfo->log_slice_name, found_log_slice_name.c_str(),
+            sizeof(linfo->log_slice_name) - 1);
+
+    size_t first_dot = found_log_slice_name.find('.');
+    if (first_dot == std::string::npos) {
+      error = LOG_INFO_IO;
+      break;
+    }
+    size_t second_dot = found_log_slice_name.find('.', first_dot + 1);
+    if (second_dot == std::string::npos) {
+      error = LOG_INFO_IO;
+      break;
+    }
+    std::string log_name = found_log_slice_name.substr(0, second_dot);
+    strmake(linfo->log_file_name, log_name.c_str(),
+            sizeof(linfo->log_file_name) - 1);
+    left_string = found_log_slice_name.substr(second_dot + 1);
+    size_t third_dot = left_string.find('.');
+    if (third_dot == std::string::npos) {
+      error = LOG_INFO_IO;
+      break;
+    }
+    std::string term = left_string.substr(0, third_dot);
+    std::string end_pos = left_string.substr(third_dot + 1);
+    linfo->slice_consensus_term = std::stoull(term);
+    linfo->slice_end_pos = std::stoull(end_pos);
+
+    linfo->entry_index++;
+    linfo->index_file_offset = my_b_tell(index_file);
+    // Found the next log file.
+    if (compare_log_name(log_name.c_str(), previous_log_name.c_str()) != 0) {
+      next_log = true;
+    }
+    // Find next binlog or next slice
+    if (found_slice || next_log == true) {
+      break;
+    }
+  }
+
+  return error;
+}
+
+int Binlog_archive_replica::find_next_log_slice(LOG_ARCHIVED_INFO *linfo,
+                                                bool &next_log) {
+  DBUG_TRACE;
+  return find_next_log_common(&m_index_file, linfo, next_log, true);
+}
+
+static int compare_log_name(const char *log_1, const char *log_2) {
+  const char *log_1_basename = log_1 + dirname_length(log_1);
+  const char *log_2_basename = log_2 + dirname_length(log_2);
+
+  return strcmp(log_1_basename, log_2_basename);
+}
+
+/**
+ * @brief Remove file or directory.
+ * @param file file or directory name.
+ * @return true, if error.
+ * @return false, if success or file not exists.
+ */
+static bool remove_file(const std::string &file) {
+  DBUG_TRACE;
+
+  uint i = 0;
+  MY_DIR *dir = nullptr;
+  MY_STAT stat_area;
+
+  if (!my_stat(file.c_str(), &stat_area, MYF(0))) return false;
+  if (!MY_S_ISDIR(stat_area.st_mode)) {
+    if (my_delete(file.c_str(), MYF(MY_WME))) return true;
+    return false;
+  }
+
+  char dir_path[FN_REFLEN + 1] = {0};
+  strmake(dir_path, file.c_str(), sizeof(dir_path) - 1);
+  convert_dirname(dir_path, dir_path, NullS);
+
+  // open directory.
+  if (!(dir = my_dir(dir_path, MYF(MY_DONT_SORT | MY_WANT_STAT)))) {
+    return true;
+  }
+
+  // Iterate through the source directory.
+  for (i = 0; i < (uint)dir->number_off_files; i++) {
+    // Skip . and ..
+    if (strcmp(dir->dir_entry[i].name, ".") == 0 ||
+        strcmp(dir->dir_entry[i].name, "..") == 0) {
+      continue;
+    }
+    std::string tmp_sub;
+    tmp_sub.assign(dir_path);
+    tmp_sub.append(dir->dir_entry[i].name);
+    if (remove_file(tmp_sub)) {
+      return true;
+    }
+  }
+  my_dirend(dir);
+
+  // remove the directory.
+  if (rmdir(dir_path)) {
+    return true;
+  }
+
+  return false;
+}

--- a/sql/binlog_archive_replica.cc
+++ b/sql/binlog_archive_replica.cc
@@ -153,6 +153,9 @@ int Binlog_archive_replica::channel_create() {
   mi = channel_map.get_mi(BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME);
 
   if (mi) {
+    err_msg.assign("binlog archive replica channel already exists ");
+    err_msg.append(BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME);
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
     goto err;
   }
   /* create a new binlog archive replica channel if doesn't exist */
@@ -160,7 +163,7 @@ int Binlog_archive_replica::channel_create() {
   // For the first creation of an mi, the locally restored latest consensus
   // index is used as the starting synchronization point with the source object
   // storage.
-  err_msg.assign("create binlog archive channel ");
+  err_msg.assign("create binlog archive replica new channel ");
   err_msg.append(BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME);
   if ((error = add_new_channel(&mi, BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME))) {
     err_msg.append(" failed");
@@ -169,31 +172,30 @@ int Binlog_archive_replica::channel_create() {
     goto err;
   }
   err_msg.append(" success");
-  LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
   if ((error = load_mi_and_rli_from_repositories(
            mi, false, SLAVE_IO | SLAVE_SQL, false, true)))
     goto err;
   // Initialize the channel master info start binlog and position with the
   // source object storage
-  if (opt_binlog_archive_replica_source_log_file != nullptr) {
-    mysql_mutex_lock(mi->rli->relay_log.get_log_lock());
-    mysql_mutex_lock(&mi->data_lock);
-    mi->set_master_log_name(opt_binlog_archive_replica_source_log_file);
-    mi->set_master_log_pos(opt_binlog_archive_replica_source_log_pos);
-    // Flush the master info to the repository
-    flush_master_info(mi, true, false);
-    mysql_mutex_unlock(&mi->data_lock);
-    mysql_mutex_unlock(mi->rli->relay_log.get_log_lock());
+  assert(opt_binlog_archive_replica_source_log_file);
+  mysql_mutex_lock(mi->rli->relay_log.get_log_lock());
+  mysql_mutex_lock(&mi->data_lock);
+  mi->set_master_log_name(opt_binlog_archive_replica_source_log_file);
+  mi->set_master_log_pos(opt_binlog_archive_replica_source_log_pos);
+  // Flush the master info to the repository
+  flush_master_info(mi, true, false);
+  mysql_mutex_unlock(&mi->data_lock);
+  mysql_mutex_unlock(mi->rli->relay_log.get_log_lock());
 
-    err_msg.assign("init binlog replica channel master info position");
-    err_msg.append(mi->get_for_channel_str());
-    err_msg.append(" file=");
-    err_msg.append(mi->get_master_log_name());
-    err_msg.append(" pos=");
-    err_msg.append(std::to_string(mi->get_master_log_pos()));
-    // print the current replication position
-    LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
-  }
+  err_msg.assign("init binlog archive replica channel master info position");
+  err_msg.append(mi->get_for_channel_str());
+  err_msg.append(" file=");
+  err_msg.append(mi->get_master_log_name());
+  err_msg.append(" pos=");
+  err_msg.append(std::to_string(mi->get_master_log_pos()));
+  // print the current replication position
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
 
 err:
   channel_map.unlock();
@@ -217,13 +219,14 @@ int Binlog_archive_replica::channel_start() {
     goto err;
   }
 
+  //clear_info(mi);
   /*
     Read the channel configuration from the repository if the channel name
     was read from the repository.
     load_mi_and_rli_from_repositories -> rli_init_info() -> init_recovery
   */
   if ((error = load_mi_and_rli_from_repositories(
-           mi, false, SLAVE_IO | SLAVE_SQL, false, true)))
+           mi, false, SLAVE_IO | SLAVE_SQL, false, false)))
     goto err;
   err_msg.assign(
       "load binlog archive replica channel master info and rli info");
@@ -233,7 +236,7 @@ int Binlog_archive_replica::channel_start() {
   err_msg.append(" pos=");
   err_msg.append(std::to_string(mi->get_master_log_pos()));
   // print the current replication position
-  LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
 
   lex_mi->channel = BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME;
   lex_connection.reset();
@@ -244,6 +247,8 @@ int Binlog_archive_replica::channel_start() {
     mi->rli->channel_mts_submode = MTS_PARALLEL_TYPE_DB_NAME;
   else
     mi->rli->channel_mts_submode = MTS_PARALLEL_TYPE_LOGICAL_CLOCK;
+  mi->abort_slave = false;
+  mi->rli->abort_slave = false;
   // Startup applier threads
   if ((error =
            start_slave(m_thd, &lex_connection, lex_mi, SLAVE_SQL, mi, false))) {
@@ -294,6 +299,7 @@ int Binlog_archive_replica::channel_stop() {
   m_thd->reset_skip_readonly_check();
   unlock_slave_threads(mi);
   mi->channel_unlock();
+  m_master_info = nullptr;
 err:
   channel_map.unlock();
   return error;
@@ -327,7 +333,6 @@ Binlog_archive_replica_io_worker::Binlog_archive_replica_io_worker(
     Binlog_archive_replica *archive, int worker_id)
     : m_archive(archive),
       m_worker_id(worker_id),
-      m_current_slice(),
       m_thd(nullptr),
       m_thd_state(),
       atomic_binlog_archive_replica_io_worker_waiting(true) {
@@ -361,8 +366,8 @@ bool Binlog_archive_replica_io_worker::start() {
     mysql_mutex_unlock(&m_worker_run_lock);
     return false;
   }
-  thread_set_created();
-  while (is_thread_alive_not_running()) {
+  m_thd_state.set_created();
+  while (m_thd_state.is_alive_not_running()) {
     DBUG_PRINT(
         "sleep",
         ("Waiting for binlog archive replica io worker thread to start"));
@@ -383,7 +388,7 @@ void Binlog_archive_replica_io_worker::stop() {
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
          "terminate begin");
   mysql_mutex_lock(&m_worker_run_lock);
-  if (is_thread_dead()) {
+  if (m_thd_state.is_thread_dead()) {
     LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
            "terminated");
     mysql_mutex_unlock(&m_worker_run_lock);
@@ -448,9 +453,10 @@ void *Binlog_archive_replica_io_worker::worker_thread() {
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
          "thread running");
   while (true) {
-    uint32_t retry = 5;
+    int failure_trials =
+        Binlog_archive::MAX_RETRIES_FOR_OBJECT_MANIPULATION_FAILURE;
     Binlog_expected_pull_slice slice;
-    bool is_slice_pull = false;
+    int error = 0;
 
     mysql_mutex_lock(&archive->m_slice_mutex);
     // Wait for the slice key to be available.
@@ -471,30 +477,26 @@ void *Binlog_archive_replica_io_worker::worker_thread() {
     }
     // The io worker thread is no longer waiting.
     set_binlog_archive_replica_io_worker_waiting(false);
-    // Get the slice key from the queue.
+    // Get the slice key from the expected queue.
     archive->m_expected_slice_queue.de_queue(&slice);
     mysql_mutex_unlock(&archive->m_slice_mutex);
     m_thd->EXIT_COND(nullptr);
-
     // Signal the binlog archive replica thread that maybe wait, because the
     // slice queue maybe full.
     mysql_cond_signal(&archive->m_queue_cond);
-    m_current_slice = slice;
+
     std::string slice_data_cache;
     // pull the slice to the local cache.
-    while (retry-- > 0) {
-      bool error = false;
+    while (failure_trials-- > 0) {
       err_msg.assign(" get slice object ");
       err_msg.append(slice.m_slice_keyid);
       DBUG_EXECUTE_IF("simulate_get_slice_object_error_on_io_worker", {
-        err_msg.append(" error=");
-        err_msg.append("simulate_get_slice_object_error_on_io_worker");
         LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
-               err_msg.c_str());
-        error = true;
+               "simulate_get_slice_object_error_on_io_worker");
+        goto end;
       });
-      if (error) {
-        is_slice_pull = false;
+      if (unlikely(m_thd->killed)) {
+        error = 1;
         break;
       }
 
@@ -514,23 +516,26 @@ void *Binlog_archive_replica_io_worker::worker_thread() {
         LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
                err_msg.c_str());
         my_sleep(1000);
-        is_slice_pull = false;
         continue;
       }
-      is_slice_pull = true;
+      error = 0;
       LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
              err_msg.c_str());
       break;
     }
+    // If the slice pull failed, break the loop and exit the thread.
+    // The binlog archive replica thread will retry create the io worker thread.
+    if (error) break;
+
     // Notify the binlog archive relay worker that the slice has been
-    // pull.
-    err_msg.assign("slice pull ");
-    err_msg.append("file_seq=");
+    // pulled.
+    err_msg.assign("slice pull");
+    err_msg.append(" log_slice_keyid=");
+    err_msg.append(slice.m_slice_keyid);
+    err_msg.append(" file_seq=");
     err_msg.append(std::to_string(slice.m_file_seq));
     err_msg.append(" slice_seq=");
     err_msg.append(std::to_string(slice.m_slice_seq));
-    err_msg.append(" log_slice_keyid=");
-    err_msg.append(slice.m_slice_keyid);
 
     mysql_mutex_lock(&archive->m_slice_mutex);
     // If the slice status map is empty or the slice status is not found in the
@@ -550,28 +555,19 @@ void *Binlog_archive_replica_io_worker::worker_thread() {
         archive->m_slice_status_map[slice.m_file_seq][slice.m_slice_seq];
     err_msg.append(" slice=");
     err_msg.append(slice_status.archived_info.log_slice_name);
-    err_msg.append(" consensus_end_index=");
-    err_msg.append(std::to_string(
-        slice_status.archived_info.log_slice_end_consensus_index));
+    err_msg.append(" end_pos=");
+    err_msg.append(
+        std::to_string(slice_status.archived_info.log_slice_end_pos));
     err_msg.append(" success");
-    if (is_slice_pull) {
-      slice_status.persisted = SLICE_PULL_SUCCESS;
-      slice_status.archived_info.slice_data_cache = slice_data_cache;
-      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
-             err_msg.c_str());
-    } else {
-      slice_status.persisted = SLICE_PULL_FAILED;
-      err_msg.append(" failed");
-      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
-             err_msg.c_str());
-      // TODO: If the slice pull failed, set io worker failed.
-      // Binlog archive replica thread will retry.
-    }
-
+    slice_status.persisted = SLICE_PULL_SUCCESS;
+    slice_status.archived_info.slice_data_cache = slice_data_cache;
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
+           err_msg.c_str());
     mysql_mutex_unlock(&archive->m_slice_mutex);
     mysql_cond_signal(&archive->m_map_cond);
   }
 
+end:
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_IO_WORKER, m_worker_id,
          "thread end");
 
@@ -587,11 +583,7 @@ void *Binlog_archive_replica_io_worker::worker_thread() {
 
 Binlog_archive_replica_relay_worker::Binlog_archive_replica_relay_worker(
     Binlog_archive_replica *archive)
-    : m_archive(archive),
-      m_thd(nullptr),
-      m_thd_state(),
-      atomic_relay_failed(false),
-      atomic_relay_waiting(true) {
+    : m_archive(archive), m_thd(nullptr), m_thd_state() {
   mysql_mutex_init(PSI_binlog_archive_replica_relay_worker_lock_key,
                    &m_worker_run_lock, MY_MUTEX_INIT_FAST);
   mysql_cond_init(PSI_binlog_archive_replica_relay_worker_cond_key,
@@ -622,8 +614,8 @@ bool Binlog_archive_replica_relay_worker::start() {
     mysql_mutex_unlock(&m_worker_run_lock);
     return false;
   }
-  thread_set_created();
-  while (is_thread_alive_not_running()) {
+  m_thd_state.set_created();
+  while (m_thd_state.is_alive_not_running()) {
     DBUG_PRINT("sleep",
                ("Waiting for binlog archive replica relay worker to start"));
     struct timespec abstime;
@@ -642,7 +634,7 @@ void Binlog_archive_replica_relay_worker::stop() {
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
          "terminate begin");
   mysql_mutex_lock(&m_worker_run_lock);
-  if (is_thread_dead()) {
+  if (m_thd_state.is_thread_dead()) {
     LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER, "terminated");
     mysql_mutex_unlock(&m_worker_run_lock);
     return;
@@ -771,29 +763,17 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
       m_thd->EXIT_COND(nullptr);
       break;
     }
-    mysql_mutex_unlock(&archive->m_slice_mutex);
-    m_thd->EXIT_COND(nullptr);
+    // Read the continuous slice objects that have been pulled, in the order of
+    // add_slice() by the binlog archive replica thread.
+    auto log_map = archive->m_slice_status_map.begin();
+    while (log_map != archive->m_slice_status_map.end()) {
+      auto &slice_map = log_map->second;
 
-    mysql_mutex_lock(&archive->m_slice_mutex);
-    // Process from map beginning
-    auto file_it = archive->m_slice_status_map.begin();
-    while (file_it != archive->m_slice_status_map.end()) {
-      auto &slice_map = file_it->second;
-
-      // Process slices from beginning of current file
+      // Process slices from beginning of current binlog file
       auto slice_it = slice_map.begin();
       while (slice_it != slice_map.end()) {
-        if (slice_it->second.persisted == SLICE_PULL_FAILED) {
-          err_msg.assign(" binlog slice persisted failed, slice=");
-          err_msg.append(slice_it->second.archived_info.log_slice_name);
-          LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
-                 err_msg.c_str());
-          set_relay_failed(true);
-          error = 1;
-          break;
-        }
         if (slice_it->second.persisted == SLICE_NOT_PULL) {
-          // Stop at first non-persisted slice
+          // Stop at first non-pull slice
           break;
         }
         assert(slice_it->second.persisted == SLICE_PULL_SUCCESS);
@@ -811,14 +791,15 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
       }
 
       if (slice_map.empty()) {
-        // Remove empty file map
-        file_it = archive->m_slice_status_map.erase(file_it);
+        // Remove empty binlog file map, then continue to next binlog file map
+        log_map = archive->m_slice_status_map.erase(log_map);
       } else {
-        // Stop at first file with remaining slices
+        // Stop at first file with SLICE_NOT_PULL slice.
         break;
       }
     }
     mysql_mutex_unlock(&archive->m_slice_mutex);
+    m_thd->EXIT_COND(nullptr);
 
     // Batch process pulled slices.
     if (!to_process.empty()) {
@@ -837,19 +818,30 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
         bool first_slice =
             slice.archived_info.first_slice;  // Whether the current slice is
                                               // the first slice of the binlog.
+
+        if (error || unlikely(m_thd->killed)) {
+          error = 1;
+          break;
+        }
+
         // If it is the first slice, the binlog header needs to be skipped
         // during reading; subsequent slices are read directly from position 0.
         if (first_slice) {
           reader_size = BIN_LOG_HEADER_SIZE;
+        } else if ((cache_size - (end_pos - start_read_pos)) > 0) {
+          // Jump to the start_read_pos position of the slice.
+          reader_size = cache_size - (end_pos - start_read_pos);
+          LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                 "jump to start_read_pos position of the slice");
         }
         err_msg.assign("relay event from ");
         err_msg.append(first_slice ? "the first slice " : "the slice ");
         err_msg.append(slice.archived_info.log_slice_name);
-        err_msg.append(" binlog start_read_pos=");
+        err_msg.append(" start_read_pos=");
         err_msg.append(std::to_string(start_read_pos));
-        err_msg.append(" slice end_pos=");
+        err_msg.append(" end_pos=");
         err_msg.append(std::to_string(end_pos));
-        err_msg.append(" slice size=");
+        err_msg.append(" size=");
         err_msg.append(std::to_string(cache_size));
         LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
                err_msg.c_str());
@@ -867,11 +859,13 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
               ("binlog archive replica relay thread readed event of type %s",
                Log_event::get_type_str(type)));
 
-          if (start_read_pos > BIN_LOG_HEADER_SIZE) {
+          // Indicates that the first slice of the first binlog file is read,
+          // Need send_format_description_event.
+          if (first_slice && start_read_pos > BIN_LOG_HEADER_SIZE) {
             if (type == binary_log::FORMAT_DESCRIPTION_EVENT) {
               assert(first_slice);
               LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
-                     "Format_description_log_event found ");
+                     "queue fake rotate_log_event");
               // If the starting position for reading the binlog file is in the
               // middle. Indicates that the first slice of the first binlog file
               // is read, this is binlog archive replica is running for the
@@ -888,13 +882,13 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
                                 start_read_pos,
                                 uint4korr(event_buf + SERVER_ID_OFFSET),
                                 event_checksum_alg, rotate_buf);
+              // Send fake rotate evet.
               QUEUE_EVENT_RESULT queue_res = queue_event_from_objstore(
                   archive->m_master_info, rotate_buf.c_str(),
                   rotate_buf.length(), true);
               if (queue_res == QUEUE_EVENT_ERROR_QUEUING) {
                 LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
-                       "queue Format_description_log_event relay log error");
-                set_relay_failed(true);
+                       "queue fake rotate_log_event relay log error");
                 error = 1;
                 break;
               }
@@ -926,14 +920,35 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
                   event_checksum_alg < binary_log::BINLOG_CHECKSUM_ALG_ENUM_END)
                 calc_event_checksum(event_ptr, event_len);
               LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
-                     "Format_description_log_event fixed ");
-            } else {
-              assert(!first_slice && (end_pos > start_read_pos));
-              // Jump to the start_read_pos position of the slice.
-              reader_size = cache_size - (end_pos - start_read_pos);
-              LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
-                     "jump to start_read_pos");
-              continue;
+                     "queue Format_description_log_event ");
+              // Send Format_description_log_event
+              queue_res = queue_event_from_objstore(archive->m_master_info,
+                                                    event_buf, event_len, true);
+              if (queue_res == QUEUE_EVENT_ERROR_QUEUING) {
+                LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                       "queue fixed Format_description_log_event error");
+                error = 1;
+                break;
+              }
+              // After reading the FORMAT_DESCRIPTION_EVENT of the first slice
+              // of the first binlog, is this slice no longer needed? This
+              // indicates that this slice is only used to read the
+              // FORMAT_DESCRIPTION_EVENT.
+              if (start_read_pos >= end_pos) {
+                // Skip current slice.
+                LogErr(INFORMATION_LEVEL,
+                       ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                       "skip current slice");
+                break;
+              } else {
+                assert(cache_size == end_pos);
+                // Jump to the start_read_pos position of the first slice.
+                reader_size = start_read_pos;
+                LogErr(INFORMATION_LEVEL,
+                       ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
+                       "jump to start_read_pos");
+                continue;
+              }
             }
           }
 
@@ -945,37 +960,19 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
           if (queue_res == QUEUE_EVENT_ERROR_QUEUING) {
             LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
                    "queue event error");
-            set_relay_failed(true);
             error = 1;
             break;
           }
           // If the starting position for reading the binlog file is in the
           // middle, after reading the format_description_log_event, events
-          // before the starting position need to be skipped, and events should
-          // be read starting from the specified start_read_pos position.
-          // This only occurs when reading the first binlog file; subsequent
-          // binlog files are read starting from position BIN_LOG_HEADER_SIZE.
-          if (first_slice && start_read_pos > BIN_LOG_HEADER_SIZE) {
-            // After reading the FORMAT_DESCRIPTION_EVENT of the first slice of
-            // the first binlog, is this slice no longer needed?
-            // This indicates that this slice is only used to read the
-            // FORMAT_DESCRIPTION_EVENT.
-            if (start_read_pos >= end_pos) {
-              // Skip current slice.
-              LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
-                     "skip current slice");
-              break;
-            } else {
-              assert(cache_size == end_pos);
-              // Jump to the start_read_pos position of the first slice.
-              reader_size = start_read_pos;
-              LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
-                     "jump to start_read_pos");
-              continue;
-            }
-          }
+          // before the starting position need to be skipped, and events
+          // should be read starting from the specified start_read_pos
+          // position. This only occurs when reading the first binlog file;
+          // subsequent binlog files are read starting from position
+          // BIN_LOG_HEADER_SIZE.
           reader_size += event_len;
         }
+        if (error) break;
         err_msg.assign("relay position");
         err_msg.append(archive->m_master_info->get_for_channel_str());
         err_msg.append(" file=");
@@ -986,8 +983,8 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
         // print the current replication position
         LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA_RELAY_WORKER,
                err_msg.c_str());
-        if (error) break;
       }
+      if (error) break;
     }
   }
 
@@ -1004,7 +1001,8 @@ void *Binlog_archive_replica_relay_worker::worker_thread() {
 }
 
 /**
- * @brief Creates a binlog archive object and starts the binlog archive thread.
+ * @brief Creates a binlog archive object and starts the binlog archive
+ * thread.
  * @return int 0 if the binlog archive thread was successfully started, 1
  * otherwise.
  */
@@ -1027,6 +1025,14 @@ int start_binlog_archive_replica() {
     LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
            "need enable relay_log_recovery");
     return 0;
+  }
+
+  if (!opt_binlog_archive_replica_source_log_file ||
+      strlen(opt_binlog_archive_replica_source_log_file) == 0) {
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "binlog archive replica channel need "
+           "binlog_archive_replica_source_log_file");
+    return 1;
   }
 
   if (!opt_binlog_archive_dir) {
@@ -1193,7 +1199,6 @@ Binlog_archive_replica::Binlog_archive_replica()
       m_slice_status_map(),
       m_thd(nullptr),
       m_thd_state(),
-      m_description_event(BINLOG_VERSION, ::server_version),
       binlog_objstore(nullptr),
       m_index_file() {
   m_mysql_archive_dir[0] = '\0';
@@ -1203,7 +1208,7 @@ Binlog_archive_replica::Binlog_archive_replica()
   m_relay_worker = nullptr;
   m_workers = nullptr;
   m_start_binlog_file[0] = '\0';
-  m_start_binlog_pos = 0;
+  m_start_binlog_pos = BIN_LOG_HEADER_SIZE;
 }
 
 /**
@@ -1326,8 +1331,7 @@ void Binlog_archive_replica::run() {
   DBUG_TRACE;
   DBUG_PRINT("info", ("Binlog_archive_replica::run"));
   std::string err_msg{};
-  int error = 0;
-  bool first_run = true;
+  bool is_send_format_description_event = true;
 
   m_thd = set_thread_context();
 
@@ -1343,8 +1347,8 @@ void Binlog_archive_replica::run() {
                   sizeof(m_mysql_binlog_archive_dir) -
                       BINLOG_ARCHIVE_SUBDIR_LEN - 1),
           STRING_WITH_LEN(BINLOG_ARCHIVE_SUBDIR));
-  // if m_binlog_archive_dir dir not exists, start_binlog_archive() will create
-  // it.
+  // if m_binlog_archive_dir dir not exists, start_binlog_archive() will
+  // create it.
   convert_dirname(m_mysql_binlog_archive_dir, m_mysql_binlog_archive_dir,
                   NullS);
 
@@ -1375,38 +1379,25 @@ void Binlog_archive_replica::run() {
   Binlog_expected_pull_slice slice;
   m_expected_slice_queue.m_Q.resize(m_expected_slice_queue.capacity, slice);
   assert(m_expected_slice_queue.m_Q.size() == m_expected_slice_queue.capacity);
+  m_last_expected_file_seq = 0;
+  m_last_expected_slice_seq = 0;
 
   // Create new binlog archive replica channel, if not exists.
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
          "create binlog archive replica channel");
-  channel_create();
-
-  // create binlog archive replica relay worker.
-  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
-         "create binlog archive replica relay worker");
-  m_relay_worker = new Binlog_archive_replica_relay_worker(this);
-  if (!m_relay_worker->start()) goto end;
-
-  // create binlog archive replica io worker thread.
-  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
-         "create binlog archive replica io worker");
-  m_workers = static_cast<Binlog_archive_replica_io_worker **>(
-      my_malloc(PSI_NOT_INSTRUMENTED,
-                opt_binlog_archive_parallel_workers *
-                    sizeof(Binlog_archive_replica_io_worker *),
-                MYF(MY_WME)));
-  if (!m_workers) goto end;
-  for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
-    Binlog_archive_replica_io_worker *worker =
-        new Binlog_archive_replica_io_worker(this, i);
-    m_workers[i] = worker;
-    if (!worker->start()) goto end;
+  if (channel_create()) {
+    err_msg.assign("failed to create binlog archive replica channel");
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+    goto end;
   }
 
-  m_last_expected_file_seq = 0;
-  m_last_expected_slice_seq = 0;
+  if (start_worker_threads()) {
+    goto end;
+  }
   for (;;) {
-    error = 0;
+    LOG_ARCHIVED_INFO log_info{};
+    int error = 0;
+
     mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
     if (m_thd == nullptr || unlikely(m_thd->killed)) {
       err_msg.assign("killed");
@@ -1419,8 +1410,10 @@ void Binlog_archive_replica::run() {
 #ifdef WESQL_CLUSTER
     // Check whether consensus role is leader
     uint64_t consensus_term = 0;
-    // Check whether consensus role is leader and fetch leader term
-    if (DBUG_EVALUATE_IF("fault_injection_binlog_archive_running", true,
+    // Check whether consensus role is leader.
+    // Only the leader can apply binlog. The nunleader will report failure,
+    // when sql apply binlog.
+    if (DBUG_EVALUATE_IF("fault_injection_binlog_archive_replica_running", true,
                          false) ||
         !is_consensus_replication_state_leader(consensus_term)) {
       struct timespec abstime;
@@ -1433,149 +1426,185 @@ void Binlog_archive_replica::run() {
       continue;
     }
 #endif
-    // Startup applier thread.
-    if (!channel_is_running() && (error = channel_start())) {
-      err_msg.assign(
-          "failed to start binlog archive replica applier sql thread");
-      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
-      break;
-    }
 
-    LOG_ARCHIVED_INFO log_info{};
+    // If any worker thread is not running, stop all worker threads and
+    // reinitialize the binlog archive replica, then restart the worker
+    // threads.
+    if (!worker_threads_are_running()) {
+      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+             "restart binlog archive replica worker threads");
+      if (stop_worker_threads() || !reinitiate_archive_replica() ||
+          start_worker_threads()) {
+        goto end;
+      }
+      is_send_format_description_event = true;
+    }
+    assert(m_master_info);
+    // If start_binlog_file is empty, init start binlog file and position
+    // using mi info.
+    if (m_start_binlog_file[0] == '\0') {
+      assert(m_master_info->get_master_log_name() &&
+             m_master_info->get_master_log_name()[0] != '\0');
+      strmake(m_start_binlog_file, m_master_info->get_master_log_name(),
+              sizeof(m_start_binlog_file) - 1);
+      m_start_binlog_pos = m_master_info->get_master_log_pos();
+      err_msg.assign("init binlog replica start_binlog_file=");
+      err_msg.append(m_start_binlog_file);
+      err_msg.append(" star_pos=");
+      err_msg.append(std::to_string(m_start_binlog_pos));
+      err_msg.append(" from channel master info");
+      err_msg.append(m_master_info->get_for_channel_str());
+      LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+    }
+    assert(m_start_binlog_file[0] != '\0');
+    assert(m_start_binlog_pos > BIN_LOG_HEADER_SIZE);
+
     mysql_mutex_lock(&m_index_lock);
     // open persistent binlog.index from source object storage.
     // Fetch the latest binlog index from the source object storage.
+    // The binlog archive replica thread periodically retrieves the
+    // binlog.index from the source object storage to check if there are any
+    // incremental binlogs slice that need to be applied.
     if (open_index_file()) {
       mysql_mutex_unlock(&m_index_lock);
       LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
              "failed to open source binlog index file");
       goto end;
     }
-    if (!first_run && m_start_binlog_file[0] != '\0') {
-      my_off_t last_slice_end_pos;
+    my_off_t last_slice_end_pos;
+    bool binlog_updated = false;
+    err_msg.assign(
+        "Find more binlog slice from persistent binlog index,  "
+        "start_binlog=");
+    err_msg.append(m_start_binlog_file);
+    err_msg.append(" start_pos=");
+    err_msg.append(std::to_string(m_start_binlog_pos));
+    // Find more binlog slice replication from source persistent
+    // binlog.index.
+    error = find_log_pos_by_name(&log_info, m_start_binlog_file);
+    if (error == 0) {
       bool next_log = false;
-      bool binlog_updated = false;
-      err_msg.assign("Find binlog from persistent binlog index, binlog=");
-      err_msg.append(m_start_binlog_file);
-      err_msg.append(" pos=");
-      err_msg.append(std::to_string(m_start_binlog_pos));
-      // Find more binlog slice replication from source persistent
-      // binlog.index.
-      error = find_log_pos_by_name(&log_info, m_start_binlog_file);
-      if (error == 0) {
-        do {
-          last_slice_end_pos = log_info.slice_end_pos;
-          if (next_log || m_start_binlog_pos < last_slice_end_pos) {
-            // Already more binlog slice need replica.
-            binlog_updated = true;
-            break;
-          }
-        } while (!(error = find_next_log_slice(&log_info, next_log)));
-        if (error != LOG_INFO_IO && !binlog_updated) {
-          if (m_start_binlog_pos == last_slice_end_pos) {
-            close_index_file();
-            mysql_mutex_unlock(&m_index_lock);
-            // If no more binlog slice to pull in source object store, retry
-            // after 1 second.
-            struct timespec abstime;
-            set_timespec(&abstime, 1);
-            mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
-            error = mysql_cond_timedwait(&m_binlog_archive_replica_run_cond,
-                                         &m_binlog_archive_replica_run_lock,
-                                         &abstime);
-            mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
-            continue;
-          } else {
-            error = 1;
-          }
+      do {
+        last_slice_end_pos = log_info.slice_end_pos;
+        if (next_log || m_start_binlog_pos < last_slice_end_pos) {
+          // Already more binlog slice need replica.
+          binlog_updated = true;
+          break;
         }
-      }
-      if (error) {
+      } while (!(error = find_next_log_slice(&log_info, next_log)));
+
+      if (error == LOG_INFO_IO) {
         close_index_file();
         mysql_mutex_unlock(&m_index_lock);
-        err_msg.append(", not found");
+        err_msg.append(" failed");
         LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
         goto end;
       }
+      // If not found more binlog slice need replica, wait for 1 second
+      // retry.
+      if (!binlog_updated) {
+        if (m_start_binlog_pos == last_slice_end_pos) {
+          close_index_file();
+          mysql_mutex_unlock(&m_index_lock);
+          // If no more binlog slice to pull in source object store, retry
+          // after 1 second.
+          struct timespec abstime;
+          set_timespec(&abstime, opt_binlog_archive_replica_flush_period);
+          mysql_mutex_lock(&m_binlog_archive_replica_run_lock);
+          error = mysql_cond_timedwait(&m_binlog_archive_replica_run_cond,
+                                       &m_binlog_archive_replica_run_lock,
+                                       &abstime);
+          mysql_mutex_unlock(&m_binlog_archive_replica_run_lock);
+          continue;
+        } else {
+          close_index_file();
+          mysql_mutex_unlock(&m_index_lock);
+          err_msg.append(" failed, binlog index position mismatch ");
+          err_msg.append(" expected start_pos=");
+          err_msg.append(std::to_string(m_start_binlog_pos));
+          err_msg.append(", but the last slice position=");
+          err_msg.append(std::to_string(last_slice_end_pos));
+          LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+          goto end;
+        }
+      }
+    } else {
+      close_index_file();
+      mysql_mutex_unlock(&m_index_lock);
+      err_msg.append(", not found replica start binlog ");
+      err_msg.append(
+          ", maybe the binlog is purged. Need to clone database "
+          "from source object store");
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+      goto end;
     }
 
-    // Init start binlog file and position.
-    if (m_start_binlog_file[0] == '\0' &&
-        m_master_info->get_master_log_name() &&
-        m_master_info->get_master_log_name()[0] != '\0') {
-      strmake(m_start_binlog_file, m_master_info->get_master_log_name(),
-              sizeof(m_start_binlog_file) - 1);
-      m_start_binlog_pos = m_master_info->get_master_log_pos();
-      err_msg.assign("init persistent binlog replica start_binlog_file=");
-      err_msg.append(m_start_binlog_file);
-      err_msg.append(" star_pos=");
-      err_msg.append(std::to_string(m_start_binlog_pos));
-      LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
-    }
-    // Find start binlog file from the persistent binlog index.
+    // Find the first slice of start binlog file from the source binlog index.
     if (!(error = find_log_pos_by_name(&log_info, m_start_binlog_file))) {
-      bool next_log = false;
-      if (m_start_binlog_file[0] == '\0') {
-        // Start from the first binlog file in the binlog.index.
-        mysql_mutex_lock(&m_master_info->data_lock);
-        m_master_info->set_master_log_name(log_info.log_file_name);
-        m_master_info->set_master_log_pos(BIN_LOG_HEADER_SIZE);
-        mysql_mutex_unlock(&m_master_info->data_lock);
-        strmake(m_start_binlog_file, log_info.log_file_name,
-                sizeof(m_start_binlog_file) - 1);
-        m_start_binlog_pos = BIN_LOG_HEADER_SIZE;
-        err_msg.assign("init persistent binlog replica start_binlog_file=");
-        err_msg.append(m_start_binlog_file);
-        err_msg.append(" star_pos=");
-        err_msg.append(std::to_string(m_start_binlog_pos));
-        LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
-      }
-      // If startup on the first time, read format_description_event from
-      // the the first binlog slice in start_binlog_file.
-      if (first_run) {
-        err_msg.assign(
-            " when first running, read expected the first slice key from "
-            "index ");
+      // When startup on the first time and create new channel, need read
+      // format_description_event from the the first slice of
+      // start_binlog_file. So we need to add the first slice in the first
+      // binlog file to the expected slice queue. Regardless of whether
+      // m_start_binlog_pos > en_pos. Refer to rpl_binlog_sender.cc.
+      if (is_send_format_description_event) {
+        err_msg.assign("read expected the first slice of start binlog ");
         err_msg.append(m_start_binlog_file);
         err_msg.append(" start_pos=");
         err_msg.append(std::to_string(m_start_binlog_pos));
-        LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+        err_msg.append(" slice_end_pos=");
+        err_msg.append(std::to_string(log_info.slice_end_pos));
+        LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
         if (!add_slice(log_info, true, m_start_binlog_pos)) {
           close_index_file();
           mysql_mutex_unlock(&m_index_lock);
-          err_msg.append("failed");
-          LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
           goto end;
         }
-        first_run = false;
+        is_send_format_description_event = false;
       }
-
-      // Get next binlig slice.
+      bool next_log = false;
+      // Read next binlig slice of current binlog file or next new binlog
+      // file.
       while (!(error = find_next_log_slice(&log_info, next_log))) {
-        // Skip binlog slice if the end position is less equal than the start
+        // Skip binlog slice if the end position of the current binlog file is
+        // less equal than the start position. This indicates that the binlog
+        // slice already is applied.
         if (!next_log && log_info.slice_end_pos <= m_start_binlog_pos) {
           continue;
         }
-        // If the next log slice is not the same as the previous log slice,
-        // read the format description event from the next log slice.
-        err_msg.assign(" read expected binlog slice key from index ");
-        err_msg.append(log_info.log_file_name);
-        err_msg.append(" start_pos=");
-        err_msg.append(std::to_string(log_info.slice_end_pos));
-        if (!add_slice(log_info, next_log, BIN_LOG_HEADER_SIZE)) {
-          close_index_file();
-          mysql_mutex_unlock(&m_index_lock);
-          err_msg.append("failed");
-          LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
-          goto end;
-        }
-        // Update the start binlog file and position.
+        // Add next binlog slice or the first slice of next binlog file.
         if (next_log) {
           strmake(m_start_binlog_file, log_info.log_file_name,
                   sizeof(m_start_binlog_file) - 1);
+          if (!add_slice(log_info, next_log, BIN_LOG_HEADER_SIZE)) {
+            close_index_file();
+            mysql_mutex_unlock(&m_index_lock);
+            goto end;
+          }
+        } else {
+          if (!add_slice(log_info, next_log, m_start_binlog_pos)) {
+            close_index_file();
+            mysql_mutex_unlock(&m_index_lock);
+            goto end;
+          }
         }
+        // Set start_read_pos of the next binlog slice.
+        // The end position of the binlog slice, and also the start position
+        // of the next binlog slice.
         m_start_binlog_pos = log_info.slice_end_pos;
         LogErr(INFORMATION_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+      }
+    } else {
+      // If start_binlog is not empty, but not found in the source binlog
+      // index, maybe the binlog is purged, need to init database by clone
+      // from source object store.
+      if (error == LOG_INFO_EOF && m_start_binlog_file[0] != '\0') {
+        err_msg.assign("not found replica start binlog ");
+        err_msg.append(m_start_binlog_file);
+        err_msg.append(
+            ", maybe the binlog is purged. Need to clone database "
+            "from source object store");
+        LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
+        goto end;
       }
     }
     close_index_file();
@@ -1583,29 +1612,12 @@ void Binlog_archive_replica::run() {
     if (error == LOG_INFO_IO) {
       err_msg.assign("failed to read binlog index file");
       LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
-      break;
+      goto end;
     }
   }
 
 end:
-  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
-         "stopping binlog archive replica index worker");
-  if (m_relay_worker) {
-    delete m_relay_worker;
-    m_relay_worker = nullptr;
-  }
-  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
-         "stopping binlog archive replica io worker");
-  for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
-    Binlog_archive_replica_io_worker *worker = m_workers[i];
-    delete worker;
-  }
-  if (m_workers) {
-    my_free(m_workers);
-    m_workers = nullptr;
-  }
-
-  channel_stop();
+  stop_worker_threads();
   LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
          "binlog archive replica thread end");
   m_thd->clear_error();
@@ -1620,10 +1632,132 @@ end:
   my_thread_exit(nullptr);
 }
 
+int Binlog_archive_replica::start_worker_threads() {
+  int error = 0;
+
+  DBUG_SIGNAL_WAIT_FOR(m_thd, "pause_before_start_worker_threads",
+                       "reached_pause_on_start_worker_threads",
+                       "continue_start_worker_threads");
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "create binlog archive replica applier sql thread");
+  // Startup sql applier thread.
+  if ((error = channel_start())) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "failed to start binlog archive replica applier sql thread");
+    goto err;
+  }
+
+  // create binlog archive replica relay worker.
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "create binlog archive replica relay thread");
+  m_relay_worker = new Binlog_archive_replica_relay_worker(this);
+  if (!m_relay_worker || !m_relay_worker->start()) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "failed to start binlog archive replica relay thread");
+    error = 1;
+    goto err;
+  }
+
+  // create binlog archive replica io worker thread.
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "create binlog archive replica io thread");
+  m_workers = static_cast<Binlog_archive_replica_io_worker **>(
+      my_malloc(PSI_NOT_INSTRUMENTED,
+                opt_binlog_archive_parallel_workers *
+                    sizeof(Binlog_archive_replica_io_worker *),
+                MYF(MY_WME)));
+  if (!m_workers) {
+    error = 1;
+    goto err;
+  }
+  for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
+    Binlog_archive_replica_io_worker *worker =
+        new Binlog_archive_replica_io_worker(this, i);
+    m_workers[i] = worker;
+    if (!worker || !worker->start()) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+             "failed to start binlog archive replica io thread");
+      error = 1;
+      goto err;
+    }
+  }
+err:
+  return error;
+}
+
+int Binlog_archive_replica::stop_worker_threads() {
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "stopping binlog archive replica relay thread");
+  if (m_relay_worker) {
+    delete m_relay_worker;
+    m_relay_worker = nullptr;
+  }
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "stopping binlog archive replica io thread");
+  if (m_workers) {
+    for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
+      Binlog_archive_replica_io_worker *worker = m_workers[i];
+      delete worker;
+    }
+
+    my_free(m_workers);
+    m_workers = nullptr;
+  }
+
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+         "stopping binlog archive replica apply sql thread");
+  channel_stop();
+  return 0;
+}
+
+bool Binlog_archive_replica::worker_threads_are_running() {
+  if (!channel_is_running()) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "binlog archive replica apply sql thread is not running");
+    return false;
+  }
+  if (!m_relay_worker || m_relay_worker->is_thread_dead() || !m_workers) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "binlog archive replica relay thread is not running");
+    return false;
+  }
+  for (ulong i = 0; i < opt_binlog_archive_parallel_workers; ++i) {
+    if (!m_workers[i] || m_workers[i]->is_thread_dead()) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+             "binlog archive replica io thread is not running");
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Binlog_archive_replica::reinitiate_archive_replica() {
+  mysql_mutex_lock(&m_slice_mutex);
+  assert(m_expected_slice_queue.inited_queue == true);
+  m_expected_slice_queue.m_Q.clear();
+  m_expected_slice_queue.avail = 0;
+  m_expected_slice_queue.entry = 0;
+  m_expected_slice_queue.len = 0;
+  Binlog_expected_pull_slice slice;
+  m_expected_slice_queue.m_Q.resize(m_expected_slice_queue.capacity, slice);
+  assert(m_expected_slice_queue.m_Q.size() == m_expected_slice_queue.capacity);
+  assert(m_expected_slice_queue.empty());
+  m_slice_status_map.clear();
+  assert(m_slice_status_map.empty());
+  m_last_expected_file_seq = 0;
+  m_last_expected_slice_seq = 0;
+  mysql_mutex_unlock(&m_slice_mutex);
+  m_start_binlog_file[0] = '\0';
+  m_start_binlog_pos = BIN_LOG_HEADER_SIZE;
+  return true;
+}
 /**
- * @brief Add a slice to the expected slice queue.
+ * @brief Add a slice to the expected slice queue for applying.
  *
- * @param slice
+ * @param slice the slice to be added to the expected slice queue for
+ * applying.
+ * @param first_slice whether the slice is the first slice in the binlog file.
+ * @param start_read_pos the start position for reading the binlog file slice.
  */
 bool Binlog_archive_replica::add_slice(LOG_ARCHIVED_INFO &log_info,
                                        bool first_slice,
@@ -1651,28 +1785,21 @@ bool Binlog_archive_replica::add_slice(LOG_ARCHIVED_INFO &log_info,
   slice_info.first_slice = first_slice;
   slice_info.m_start_read_pos = start_read_pos;
 
-  err_msg.assign("add slice key to expected slice queue ");
-  err_msg.append("file_seq=");
+  err_msg.assign("add ");
+  err_msg.append(first_slice ? "first slice" : "slice");
+  err_msg.append(" to expected slice queue ");
+  err_msg.append(" log_slice_keyid=");
+  err_msg.append(slice_info.log_slice_name);
+  err_msg.append(" end_pos=");
+  err_msg.append(std::to_string(slice_info.log_slice_end_pos));
+  err_msg.append(" start_read_pos=");
+  err_msg.append(std::to_string(slice_info.m_start_read_pos));
+  err_msg.append(" file_seq=");
   err_msg.append(std::to_string(expected_slice.m_file_seq));
   err_msg.append(" slice_seq=");
   err_msg.append(std::to_string(expected_slice.m_slice_seq));
-  err_msg.append(" log_slice_keyid=");
-  err_msg.append(expected_slice.m_slice_keyid);
-  err_msg.append(" log_slice_name=");
-  err_msg.append(slice_info.log_slice_name);
-  err_msg.append(" consensus_end_index=");
-  err_msg.append(std::to_string(slice_info.log_slice_end_consensus_index));
-  err_msg.append(" previous_consensus_index=");
-  err_msg.append(std::to_string(slice_info.log_slice_previous_consensus_index));
-  err_msg.append(" end_pos=");
-  err_msg.append(std::to_string(slice_info.log_slice_end_pos));
-  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
 
-  DBUG_EXECUTE_IF("fault_injection_add_slice_queue", {
-    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_LOG,
-           "fault_injection_add_slice_queue");
-    return false;
-  });
+  LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, err_msg.c_str());
 
   mysql_mutex_lock(&m_slice_mutex);
   m_thd->ENTER_COND(&m_queue_cond, &m_slice_mutex, nullptr, nullptr);
@@ -1682,16 +1809,18 @@ bool Binlog_archive_replica::add_slice(LOG_ARCHIVED_INFO &log_info,
     // Or binlog archive thread is killed.
     mysql_cond_wait(&m_queue_cond, &m_slice_mutex);
   }
+  if (m_thd->killed) {
+    mysql_mutex_unlock(&m_slice_mutex);
+    m_thd->EXIT_COND(nullptr);
+    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, "thread killed");
+    return false;
+  }
   m_expected_slice_queue.en_queue(&expected_slice);
   m_slice_status_map[expected_slice.m_file_seq][expected_slice.m_slice_seq] =
       Slice_pull_status(expected_slice.m_file_seq, expected_slice.m_slice_seq,
                         slice_info);
   mysql_mutex_unlock(&m_slice_mutex);
   m_thd->EXIT_COND(nullptr);
-  if (m_thd->killed) {
-    LogErr(SYSTEM_LEVEL, ER_BINLOG_ARCHIVE_REPLICA, " thread killed");
-    return false;
-  }
   // Signal the binlog archive worker thread that wait, because the slice
   // queue is empty.
   mysql_cond_signal(&m_queue_cond);
@@ -1809,11 +1938,11 @@ bool Binlog_archive_replica::open_index_file() {
   // slices generated by the new leader. If events are relayed in this
   // scenario, it could lead to data inconsistency.
   // Solution: After obtaining the latest index through get_object(), perform
-  // another list_object() call to fetch the latest index again and check if it
-  // matches the index already retrieved. If they are consistent, the slices
-  // within the index can be used (ensuring the currently read index is the
-  // latest file and its slices are valid). Otherwise, the index needs to be
-  // re-read.
+  // another list_object() call to fetch the latest index again and check if
+  // it matches the index already retrieved. If they are consistent, the
+  // slices within the index can be used (ensuring the currently read index is
+  // the latest file and its slices are valid). Otherwise, the index needs to
+  // be re-read.
   while (true) {
     if (fetch_last_persistent_index_file(last_binlog_index_keyid)) {
       return true;
@@ -1904,30 +2033,18 @@ void Binlog_archive_replica::close_index_file() {
 
 /**
   Find the position in the log-index-file for the given log name.
-
-  @param[out] linfo The found log file name will be stored here, along
-  with the byte offset of the next log file name in the index file.
-  @param log_name Filename to find in the index file, or NULL if we
-  want to read the first entry.
-  @param need_lock_index If false, this function acquires m_index_lock;
-  otherwise the lock should already be held by the caller.
-
-  @note
-    On systems without the truncate function the file will end with one or
-    more empty lines.  These will be ignored when reading the file.
-
-  @retval
-    0			ok
-  @retval
-    LOG_INFO_EOF	        End of log-index-file found
-  @retval
-    LOG_INFO_IO		Got IO error while reading file
 */
 int Binlog_archive_replica::find_log_pos_common(
     IO_CACHE *index_file, LOG_ARCHIVED_INFO *linfo, const char *log_name,
     uint64_t consensus_index, bool last_slice [[maybe_unused]]) {
   DBUG_TRACE;
   int error = 0;
+
+  DBUG_EXECUTE_IF("simulate_find_log_error_in_source_binlog_index", {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_REPLICA,
+           "simulate_find_log_error_in_source_binlog_index");
+    return LOG_INFO_IO;
+  });
 
   /* As the file is flushed, we can't get an error here */
   my_b_seek(index_file, (my_off_t)0);
@@ -1944,19 +2061,6 @@ int Binlog_archive_replica::find_log_pos_common(
     }
     /* Get rid of the trailing '\n' */
     linfo->log_line[length - 1] = 0;
-
-    /*
-      {$binlog_file_name}.{$consensus_term}.{$slice_end_pos}|{$end_index}|{$previous_index}
-
-      binlog.000001.00000000000000000000.0000000377|0
-      binlog.000002.00000000000000000000.0000000295|1
-      binlog.000003.00000000000000000000.0000000295|1
-      binlog.000004.00000000000000000000.0000001924|1
-      binlog.000004.00000000000000000000.0000014524|1
-      binlog.000004.00000000000000000000.0000025541|1
-      binlog.000005.00000000000000000000.0000000291|11
-      binlog.000005.00000000000000000000.0000000429|11
-    */
     std::string in_str;
     in_str.assign(linfo->log_line);
     size_t idx = in_str.find("|");
@@ -2017,7 +2121,6 @@ int Binlog_archive_replica::find_log_pos_common(
     }
     linfo->entry_index++;
   }
-
   return error;
 }
 
@@ -2026,6 +2129,8 @@ int Binlog_archive_replica::find_log_pos_by_name(LOG_ARCHIVED_INFO *linfo,
   DBUG_TRACE;
 
   if (!my_b_inited(&m_index_file)) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+           "binlog index not inited");
     return LOG_INFO_IO;
   }
   return find_log_pos_common(&m_index_file, linfo, log_name, 0);
@@ -2055,6 +2160,8 @@ int Binlog_archive_replica::find_next_log(LOG_ARCHIVED_INFO *linfo) {
   bool next_log = false;
 
   if (!my_b_inited(&m_index_file)) {
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+           "binlog index not inited");
     return LOG_INFO_IO;
   }
   return find_next_log_common(&m_index_file, linfo, next_log, false);
@@ -2081,8 +2188,9 @@ int Binlog_archive_replica::find_next_log_common(IO_CACHE *index_file,
   next_log = false;
 
   if (!my_b_inited(index_file)) {
-    error = LOG_INFO_IO;
-    return error;
+    LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+           "binlog index not inited");
+    return LOG_INFO_IO;
   }
   /* As the file is flushed, we can't get an error here */
   my_b_seek(index_file, linfo->index_file_offset);
@@ -2116,11 +2224,15 @@ int Binlog_archive_replica::find_next_log_common(IO_CACHE *index_file,
 
     size_t first_dot = found_log_slice_name.find('.');
     if (first_dot == std::string::npos) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+             "Invalid log slice index entry", found_log_slice_name);
       error = LOG_INFO_IO;
       break;
     }
     size_t second_dot = found_log_slice_name.find('.', first_dot + 1);
     if (second_dot == std::string::npos) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+             "Invalid log slice index entry", found_log_slice_name);
       error = LOG_INFO_IO;
       break;
     }
@@ -2130,6 +2242,8 @@ int Binlog_archive_replica::find_next_log_common(IO_CACHE *index_file,
     left_string = found_log_slice_name.substr(second_dot + 1);
     size_t third_dot = left_string.find('.');
     if (third_dot == std::string::npos) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_ARCHIVE_OPEN_INDEX,
+             "Invalid log slice index entry", found_log_slice_name);
       error = LOG_INFO_IO;
       break;
     }

--- a/sql/binlog_archive_replica.h
+++ b/sql/binlog_archive_replica.h
@@ -182,13 +182,24 @@ class Binlog_archive_replica_io_worker {
         ->worker_thread();
   }
   void *worker_thread();
-  void thread_set_created() { m_thd_state.set_created(); }
-  bool is_thread_alive_not_running() const {
-    return m_thd_state.is_alive_not_running();
+  bool is_thread_dead() {
+    mysql_mutex_lock(&m_worker_run_lock);
+    bool ret = m_thd_state.is_thread_dead();
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return ret;
   }
-  bool is_thread_dead() const { return m_thd_state.is_thread_dead(); }
-  bool is_thread_alive() const { return m_thd_state.is_thread_alive(); }
-  bool is_thread_running() const { return m_thd_state.is_running(); }
+  bool is_thread_alive() {
+    mysql_mutex_lock(&m_worker_run_lock);
+    bool ret = m_thd_state.is_thread_alive();
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return ret;
+  }
+  bool is_thread_running() {
+    mysql_mutex_lock(&m_worker_run_lock);
+    bool ret = m_thd_state.is_running();
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return ret;
+  }
   int terminate_binlog_archive_replica_io_worker_thread();
   bool is_binlog_archive_replica_io_worker_waiting() const {
     return atomic_binlog_archive_replica_io_worker_waiting.load(
@@ -203,7 +214,6 @@ class Binlog_archive_replica_io_worker {
   Binlog_archive_replica *m_archive;
   my_thread_handle m_thread;
   int m_worker_id;
-  Binlog_expected_pull_slice m_current_slice;
   THD *m_thd;
   /* thread state */
   thread_state m_thd_state;
@@ -230,26 +240,25 @@ class Binlog_archive_replica_relay_worker {
         ->worker_thread();
   }
   void *worker_thread();
-  void thread_set_created() { m_thd_state.set_created(); }
-  bool is_thread_alive_not_running() const {
-    return m_thd_state.is_alive_not_running();
+  bool is_thread_dead() {
+    mysql_mutex_lock(&m_worker_run_lock);
+    bool ret = m_thd_state.is_thread_dead();
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return ret;
   }
-  bool is_thread_dead() const { return m_thd_state.is_thread_dead(); }
-  bool is_thread_alive() const { return m_thd_state.is_thread_alive(); }
-  bool is_thread_running() const { return m_thd_state.is_running(); }
+  bool is_thread_alive() {
+    mysql_mutex_lock(&m_worker_run_lock);
+    bool ret = m_thd_state.is_thread_alive();
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return ret;
+  }
+  bool is_thread_running() {
+    mysql_mutex_lock(&m_worker_run_lock);
+    bool ret = m_thd_state.is_running();
+    mysql_mutex_unlock(&m_worker_run_lock);
+    return ret;
+  }
   int terminate_binlog_archive_replica_relay_worker();
-  bool is_relay_failed() const {
-    return atomic_relay_failed.load(std::memory_order_acquire);
-  }
-  void set_relay_failed(bool failed) {
-    atomic_relay_failed.store(failed, std::memory_order_release);
-  }
-  bool is_relay_waiting() const {
-    return atomic_relay_waiting.load(std::memory_order_acquire);
-  }
-  void set_relay_waiting(bool waiting) {
-    atomic_relay_waiting.store(waiting, std::memory_order_release);
-  }
 
  private:
   Binlog_archive_replica *m_archive;
@@ -259,8 +268,6 @@ class Binlog_archive_replica_relay_worker {
   thread_state m_thd_state;
   mysql_mutex_t m_worker_run_lock;
   mysql_cond_t m_worker_run_cond;
-  std::atomic<bool> atomic_relay_failed;
-  std::atomic<bool> atomic_relay_waiting;
   void calc_event_checksum(uchar *event_ptr, size_t event_len);
   int fake_rotate_event(const char *next_log_file, my_off_t log_pos,
                         ulong server_id,
@@ -367,11 +374,14 @@ class Binlog_archive_replica {
   int channel_start();
   int channel_stop();
   bool channel_is_running();
+  int start_worker_threads();
+  int stop_worker_threads();
+  bool worker_threads_are_running();
+  bool reinitiate_archive_replica();
   char m_binlog_archive_file_name[FN_REFLEN + 1];
   char m_binlog_archive_dir[FN_REFLEN + 1];
   char m_mysql_archive_dir[FN_REFLEN + 1];
   char m_mysql_binlog_archive_dir[FN_REFLEN + 1];
-  Format_description_event m_description_event;
   objstore::ObjectStore *binlog_objstore;
   int archive_init();
   int archive_cleanup();

--- a/sql/binlog_archive_replica.h
+++ b/sql/binlog_archive_replica.h
@@ -1,0 +1,403 @@
+/*
+  Portions Copyright (c) 2024, ApeCloud Inc Holding Limited
+  Portions Copyright (c) 2009, 2023, Oracle and/or its affiliates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#ifndef BINLOG_ARCHIVE_REPLICA_INCLUDED
+#define BINLOG_ARCHIVE_REPLICA_INCLUDED
+
+#include "objstore.h"
+#include "sql/basic_istream.h"
+#include "sql/basic_ostream.h"
+#include "sql/binlog.h"
+#include "sql/binlog_archive.h"
+#include "sql/binlog_reader.h"
+#include "sql/rpl_io_monitor.h"
+#include "sql/rpl_rli_pdb.h"
+#include "sql/sql_error.h"
+#include "sql_string.h"
+
+#define BINLOG_ARCHIVE_REPLICA_INDEX_LOCAL_FILE "binlog_index_relay.index"
+#define BINLOG_ARCHIVE_REPLICA_CHANNEL_NAME "binlog_archive_replica"
+
+struct SLICE_PULL_INFO {
+  char log_file_name[FN_REFLEN] = {0};
+  char log_slice_name[FN_REFLEN] = {0};
+  char mysql_log_name[FN_REFLEN] = {0};
+  uint64_t log_slice_end_consensus_index;
+  uint64_t log_slice_consensus_term;
+  uint64_t log_slice_previous_consensus_index;
+  my_off_t log_slice_end_pos;
+  my_off_t mysql_end_pos;
+  int entry_index;  // used in purge_logs(), calculated in find_log_pos().
+  my_off_t m_slice_bytes_written;
+  std::string slice_data_cache;
+  bool first_slice;
+  my_off_t m_start_read_pos;
+  SLICE_PULL_INFO()
+      : log_slice_end_consensus_index(0),
+        log_slice_consensus_term(0),
+        log_slice_previous_consensus_index(0),
+        log_slice_end_pos(0),
+        mysql_end_pos(0),
+        entry_index(0),
+        m_slice_bytes_written(0),
+        slice_data_cache(),
+        first_slice(false),
+        m_start_read_pos(0) {
+    memset(log_file_name, 0, FN_REFLEN);
+    memset(log_slice_name, 0, FN_REFLEN);
+    memset(mysql_log_name, 0, FN_REFLEN);
+  }
+
+  // Copy constructor
+  SLICE_PULL_INFO(const SLICE_PULL_INFO &other)
+      : log_slice_end_consensus_index(other.log_slice_end_consensus_index),
+        log_slice_consensus_term(other.log_slice_consensus_term),
+        log_slice_previous_consensus_index(
+            other.log_slice_previous_consensus_index),
+        log_slice_end_pos(other.log_slice_end_pos),
+        mysql_end_pos(other.mysql_end_pos),
+        entry_index(other.entry_index),
+        m_slice_bytes_written(other.m_slice_bytes_written),
+        slice_data_cache(other.slice_data_cache),
+        first_slice(other.first_slice),
+        m_start_read_pos(other.m_start_read_pos) {
+    strmake(log_file_name, other.log_file_name, FN_REFLEN);
+    strmake(log_slice_name, other.log_slice_name, FN_REFLEN);
+    strmake(mysql_log_name, other.mysql_log_name, FN_REFLEN);
+  }
+
+  SLICE_PULL_INFO &operator=(const SLICE_PULL_INFO &other) {
+    if (this != &other) {
+      strmake(log_file_name, other.log_file_name, FN_REFLEN);
+      strmake(log_slice_name, other.log_slice_name, FN_REFLEN);
+      strmake(mysql_log_name, other.mysql_log_name, FN_REFLEN);
+      log_slice_end_consensus_index = other.log_slice_end_consensus_index;
+      log_slice_consensus_term = other.log_slice_consensus_term;
+      log_slice_previous_consensus_index =
+          other.log_slice_previous_consensus_index;
+      log_slice_end_pos = other.log_slice_end_pos;
+      mysql_end_pos = other.mysql_end_pos;
+      entry_index = other.entry_index;
+      slice_data_cache = other.slice_data_cache;
+      m_slice_bytes_written = other.m_slice_bytes_written;
+      first_slice = other.first_slice;
+      m_start_read_pos = other.m_start_read_pos;
+    }
+    return *this;
+  }
+};
+
+/**
+ * @brief  Binlog expected slice structure.
+ *
+ */
+struct Binlog_expected_pull_slice {
+  char m_slice_keyid[FN_REFLEN + 1];
+  uint32_t m_file_seq;
+  uint32_t m_slice_seq;
+  // Default constructor
+  Binlog_expected_pull_slice() = default;
+  // Constructor
+  Binlog_expected_pull_slice(const char *keyid, uint32_t file_seq,
+                             uint32_t slice_seq)
+      : m_file_seq(file_seq), m_slice_seq(slice_seq) {
+    strmake(this->m_slice_keyid, keyid, FN_REFLEN);
+  }
+
+  // Copy constructor
+  Binlog_expected_pull_slice(const Binlog_expected_pull_slice &other)
+      : m_file_seq(other.m_file_seq), m_slice_seq(other.m_slice_seq) {
+    strmake(m_slice_keyid, other.m_slice_keyid, FN_REFLEN);
+  }
+
+  Binlog_expected_pull_slice &operator=(
+      const Binlog_expected_pull_slice &other) {
+    if (this != &other) {
+      strmake(this->m_slice_keyid, other.m_slice_keyid, FN_REFLEN);
+      this->m_file_seq = other.m_file_seq;
+      this->m_slice_seq = other.m_slice_seq;
+    }
+    return *this;
+  }
+};
+
+enum Slice_pull_status_enum {
+  SLICE_NOT_PULL,
+  SLICE_PULL_SUCCESS,
+  SLICE_PULL_FAILED
+};
+struct Slice_pull_status {
+  Slice_pull_status_enum persisted;
+  SLICE_PULL_INFO archived_info;
+  uint32_t file_seq;
+  uint32_t slice_seq;
+  Slice_pull_status() : persisted(SLICE_NOT_PULL), file_seq(0), slice_seq(0) {}
+
+  Slice_pull_status(uint32_t f_seq, uint32_t s_seq, SLICE_PULL_INFO info)
+      : persisted(SLICE_NOT_PULL),
+        archived_info(info),
+        file_seq(f_seq),
+        slice_seq(s_seq) {}
+};
+
+class Binlog_archive_replica;
+
+/**
+ * @brief Binlog archive worker class.
+ * IO worker pulls the binlog slice from source object store, when binlog index
+ * is updated. Multiple IO workers can be created to pull the binlog slice in
+ * parallel.
+ */
+class Binlog_archive_replica_io_worker {
+ public:
+  Binlog_archive_replica_io_worker(Binlog_archive_replica *archive,
+                                   int worker_id);
+  ~Binlog_archive_replica_io_worker();
+
+  bool start();
+  void stop();
+  static void *thread_launcher(void *arg) {
+    return static_cast<Binlog_archive_replica_io_worker *>(arg)
+        ->worker_thread();
+  }
+  void *worker_thread();
+  void thread_set_created() { m_thd_state.set_created(); }
+  bool is_thread_alive_not_running() const {
+    return m_thd_state.is_alive_not_running();
+  }
+  bool is_thread_dead() const { return m_thd_state.is_thread_dead(); }
+  bool is_thread_alive() const { return m_thd_state.is_thread_alive(); }
+  bool is_thread_running() const { return m_thd_state.is_running(); }
+  int terminate_binlog_archive_replica_io_worker_thread();
+  bool is_binlog_archive_replica_io_worker_waiting() const {
+    return atomic_binlog_archive_replica_io_worker_waiting.load(
+        std::memory_order_acquire);
+  }
+  void set_binlog_archive_replica_io_worker_waiting(bool waiting) {
+    atomic_binlog_archive_replica_io_worker_waiting.store(
+        waiting, std::memory_order_release);
+  }
+
+ private:
+  Binlog_archive_replica *m_archive;
+  my_thread_handle m_thread;
+  int m_worker_id;
+  Binlog_expected_pull_slice m_current_slice;
+  THD *m_thd;
+  /* thread state */
+  thread_state m_thd_state;
+  mysql_mutex_t m_worker_run_lock;
+  mysql_cond_t m_worker_run_cond;
+  std::atomic<bool> atomic_binlog_archive_replica_io_worker_waiting;
+};
+
+/**
+ * @brief Binlog archive replica fetch index worker class.
+ * Index worker fetches the binlog index from source object store periodically.
+ * When the index is updated, it triggers the IO worker to pull the binlog
+ * slice.
+ */
+class Binlog_archive_replica_relay_worker {
+ public:
+  Binlog_archive_replica_relay_worker(Binlog_archive_replica *archive);
+  ~Binlog_archive_replica_relay_worker();
+
+  bool start();
+  void stop();
+  static void *thread_launcher(void *arg) {
+    return static_cast<Binlog_archive_replica_relay_worker *>(arg)
+        ->worker_thread();
+  }
+  void *worker_thread();
+  void thread_set_created() { m_thd_state.set_created(); }
+  bool is_thread_alive_not_running() const {
+    return m_thd_state.is_alive_not_running();
+  }
+  bool is_thread_dead() const { return m_thd_state.is_thread_dead(); }
+  bool is_thread_alive() const { return m_thd_state.is_thread_alive(); }
+  bool is_thread_running() const { return m_thd_state.is_running(); }
+  int terminate_binlog_archive_replica_relay_worker();
+  bool is_relay_failed() const {
+    return atomic_relay_failed.load(std::memory_order_acquire);
+  }
+  void set_relay_failed(bool failed) {
+    atomic_relay_failed.store(failed, std::memory_order_release);
+  }
+  bool is_relay_waiting() const {
+    return atomic_relay_waiting.load(std::memory_order_acquire);
+  }
+  void set_relay_waiting(bool waiting) {
+    atomic_relay_waiting.store(waiting, std::memory_order_release);
+  }
+
+ private:
+  Binlog_archive_replica *m_archive;
+  my_thread_handle m_thread;
+  THD *m_thd;
+  /* thread state */
+  thread_state m_thd_state;
+  mysql_mutex_t m_worker_run_lock;
+  mysql_cond_t m_worker_run_cond;
+  std::atomic<bool> atomic_relay_failed;
+  std::atomic<bool> atomic_relay_waiting;
+  void calc_event_checksum(uchar *event_ptr, size_t event_len);
+  int fake_rotate_event(const char *next_log_file, my_off_t log_pos,
+                        ulong server_id,
+                        binary_log::enum_binlog_checksum_alg event_checksum_alg,
+                        std::string &rotate_buf);
+};
+
+/**
+ * @class Binlog_archive_replica
+ * @brief The Binlog_archive_replica class is responsible for generate binary
+ * relay log files.
+ * Binlog_archive_replica is responsible for create index worker and IO worker.
+ * Binlog_archive_replicat create replica source object store information like
+ 'Master_info'.
+ * Add binlog_archive_replica channel by Multisource_info::add_mi() and
+ * Rpl_info_factory::create_mi_and_rli_objects().
+ * Refer to Replication_thread_api::initialize_channel().
+ *
+ * if (threads_to_start & CHANNEL_APPLIER_THREAD) {
+    thread_mask |= SLAVE_SQL;
+  }
+  if (threads_to_start & CHANNEL_RECEIVER_THREAD) {
+    thread_mask |= SLAVE_IO;
+  }
+ * Refer to start_slave_thread().
+ * Binlog_archive_replica call read_event() to read event from binlog slice file
+ cache,
+ * then call queue_event() to queue event to relay log queue.
+ * Index worker is responsible for fetch binlog index from source object store.
+ * IO worker is responsible for fetch binlog slice from source object store.
+ * Binlog_archive_replica is responsible for generate binary relay log files by
+ reading
+ *  event from binlog slice file.
+ * Before index worker fetch binlog index, it will check object store uuid.
+ */
+class Binlog_archive_replica {
+ public:
+  /**
+   * @brief Constructs a Binlog_archive_replica object.
+   * @param thd A pointer to the THD object.
+   */
+  Binlog_archive_replica();
+
+  /**
+   * @brief Destructs the Binlog_archive_replica object.
+   */
+  ~Binlog_archive_replica();
+
+  /**
+   * @brief Initializes.
+   */
+  void init_pthread_object();
+  /**
+   * @brief Cleans up any resources.
+   */
+  void deinit_pthread_object();
+
+  mysql_mutex_t *get_binlog_archive_lock();
+
+  static Binlog_archive_replica *get_instance();
+  /**
+   * @brief Runs the binlog archiving process.
+   */
+  void run();
+  void thread_set_created() { m_thd_state.set_created(); }
+  bool is_thread_alive_not_running() const {
+    return m_thd_state.is_alive_not_running();
+  }
+  bool is_thread_dead() const { return m_thd_state.is_thread_dead(); }
+  bool is_thread_alive() const { return m_thd_state.is_thread_alive(); }
+  bool is_thread_running() const { return m_thd_state.is_running(); }
+  int terminate_binlog_archive_replica_thread();
+  void lock_binlog_index() { mysql_mutex_lock(&m_index_lock); }
+  void unlock_binlog_index() { mysql_mutex_unlock(&m_index_lock); }
+  inline void set_objstore(objstore::ObjectStore *objstore) {
+    binlog_objstore = objstore;
+  }
+  inline objstore::ObjectStore *get_objstore() { return binlog_objstore; }
+
+  Binlog_archive_replica_relay_worker *m_relay_worker;
+  Binlog_archive_replica_io_worker **m_workers;
+
+  mysql_mutex_t m_slice_mutex;
+  circular_buffer_queue<Binlog_expected_pull_slice> m_expected_slice_queue;
+  mysql_cond_t m_queue_cond;
+  // File and slice tracking
+  std::map<uint32_t, std::map<uint32_t, Slice_pull_status>> m_slice_status_map;
+  mysql_cond_t m_map_cond;
+  // -- m_slice_mutex protects the above variables
+  int32_t m_last_expected_file_seq{-1};  // last added slice file expected queue
+  int32_t m_last_expected_slice_seq{-1};  // last added slice seq expected queue
+  Master_info *m_master_info;
+  char m_start_binlog_file[FN_REFLEN + 1];
+  my_off_t m_start_binlog_pos;
+
+ private:
+  // the binlog archive replica THD handle.
+  THD *m_thd;
+  /* thread state */
+  thread_state m_thd_state;
+  bool add_slice(LOG_ARCHIVED_INFO &log_info, bool first_slice,
+                 my_off_t start_read_pos);
+  int channel_create();
+  int channel_start();
+  int channel_stop();
+  bool channel_is_running();
+  char m_binlog_archive_file_name[FN_REFLEN + 1];
+  char m_binlog_archive_dir[FN_REFLEN + 1];
+  char m_mysql_archive_dir[FN_REFLEN + 1];
+  char m_mysql_binlog_archive_dir[FN_REFLEN + 1];
+  Format_description_event m_description_event;
+  objstore::ObjectStore *binlog_objstore;
+  int archive_init();
+  int archive_cleanup();
+  /* The mysql binlog file it is reading */
+  LOG_INFO m_mysql_linfo;
+
+  IO_CACHE m_index_file;
+  mysql_mutex_t m_index_lock;
+  char m_index_local_file_name[FN_REFLEN];
+  char m_index_file_name[FN_REFLEN];
+  bool list_persistent_objects(
+      std::vector<objstore::ObjectMeta> &persistent_objects,
+      const char *search_key, bool all, bool allow_no_search_key);
+  int fetch_last_persistent_index_file(std::string &last_index_file);
+  bool open_index_file();
+  void close_index_file();
+  int find_log_pos_by_name(LOG_ARCHIVED_INFO *linfo, const char *log_name);
+  int find_next_log(LOG_ARCHIVED_INFO *linfo);
+  int find_next_log_slice(LOG_ARCHIVED_INFO *linfo, bool &next_log);
+  int find_next_log_common(IO_CACHE *index_file, LOG_ARCHIVED_INFO *linfo,
+                           bool &next_log, bool found_slice = false);
+  int find_log_pos_common(IO_CACHE *index_file, LOG_ARCHIVED_INFO *linfo,
+                          const char *log_name, uint64_t consensus_index,
+                          bool last_slice = false);
+};
+
+extern int start_binlog_archive_replica();
+extern void stop_binlog_archive_replica();
+#endif

--- a/sql/consistent_archive.cc
+++ b/sql/consistent_archive.cc
@@ -92,9 +92,11 @@ static PSI_file_key PSI_consistent_archive_mysql_log_index_cache_key;
 static PSI_file_key PSI_consistent_archive_se_log_index_cache_key;
 static PSI_file_key PSI_consistent_snapshot_file_cache_key;
 
+// The name lenght include a terminating NUL character of thread can not exceed
+// 16 characters, if flag is PSI_FLAG_SINGLETON.
 static PSI_thread_info all_consistent_archive_threads[] = {
-    {&THR_KEY_consistent_archive, "archive", "ss_arch", PSI_FLAG_AUTO_SEQNUM, 0,
-     PSI_DOCUMENT_ME}};
+    {&THR_KEY_consistent_archive, "snapshot_archive", "snapshot_arch",
+     PSI_FLAG_SINGLETON | PSI_FLAG_THREAD_SYSTEM, 0, PSI_DOCUMENT_ME}};
 
 static PSI_mutex_info all_consistent_archive_mutex_info[] = {
     {&PSI_consistent_index_lock_key, "consistent_mutex", 0, 0, PSI_DOCUMENT_ME},

--- a/sql/consistent_recovery.h
+++ b/sql/consistent_recovery.h
@@ -99,6 +99,8 @@ class Consistent_recovery {
       std::vector<objstore::ObjectMeta> &persistent_objects,
       const char *search_key, bool recursive, bool all,
       bool allow_no_search_key);
+  bool set_binlog_variable(const char *source_binlog,
+                           my_off_t source_binlog_pos);
   enum Consistent_recovery_state {
     CONSISTENT_RECOVERY_STATE_NONE = 0,
     CONSISTENT_RECOVERY_STATE_SNAPSHOT_FILE = 1,
@@ -132,6 +134,7 @@ class Consistent_recovery {
   // state
   uint64_t m_consensus_index;
   uint64_t m_se_snapshot_id;
+  char m_binlog_end_file[FN_REFLEN + 1];
   char m_mysql_binlog_end_file[FN_REFLEN + 1];
   my_off_t m_mysql_binlog_end_pos;
   char m_snapshot_end_binlog_file[FN_REFLEN + 1];


### PR DESCRIPTION
## Objective

WeSQL Replication enables data from one WeSQL database (known as source) object storage (known as a source object storage) to be continuous copied to one or more WeSQL database servers (known as replicas). 
Similar to MySQL Replication, the difference is that WeSQL Replication performs replication through S3. WeSQL Replica Node interacts solely with the source object storage and does not concern itself with the WeSQL Source Node.

```
  +-----------------+      Persist Data       +-------------------+
  |                 |  ---------------------> |                   |
  |   WeSQL Source  |                         |       S3          |
  |                 |                         |                   |
  +-----------------+                         +-------------------+
                                                    |
                                                    |
                                               Replication
                                                    |
                                                    v
                                   +-------------------+      Persist Data     +-------------------+
                                   |                   |  ------------------>  |                   |
                                   |   WeSQL Replica   |                       |        S3         |
                                   |                   |                       |                   |
                                   +-------------------+                       +-------------------+
```


## Design

1. When the Replica starts for the first time (after the clone is completed), it automatically uses the binlog end position recorded in the source object storage during the cloning process (which is stored as a parameter after successful cloning) as the starting replication position for the Replica, and creates the binlog_archive_replica channel.

2. The Replica will create four types of threads:
**Binlog Archive Replica thread (main control thread, 1)**: Responsible for creating other threads and detecting incremental binlog updates from the source object storage.
**Binlog Archive Replica IO thread (binlog_archive_parallel_workers parameter)**: Responsible for concurrently pulling binlog objects from the source object storage into the local cache.
**Binlog Archive Replica Relay thread (1)**: Responsible for sequentially writing events from the binlog objects in the local cache to the relay log.
**SQL Applier thread (replica_parallel_workers parameter)**: Responsible for concurrently replaying the relay log (the replay logic is consistent with MySQL’s replay logic).

3. The Replica node’s main control thread periodically scans the binlog in the source database object storage to detect if there are any incremental binlog slices, scanning the binlog in units of slices. The default scanning interval is 1 second, but it can be dynamically configured via parameters.

4. If new binlog slices are found, the IO thread is responsible for concurrently pulling binlog objects.

5. Once the binlog slice objects are pulled, they are sequentially written into the relay log by the relay thread.

6. The SQL Applier thread continuously replays the incremental relay log.

7. If an error occurs during the execution of a non-main control thread, the main control thread will attempt to restart in order to recover replication behavior.

## Constraints

1. WeSQL Replication relies on the `relay_log_recovery=ON` parameter. When the Replica node restarts, it will use the replay log’s replay position as the replication starting point to ensure only binlogs that have not been replayed are pulled.

2. WeSQL Replication supports only asynchronous replication.
