### PR TITLE
bugfix: fix uneven data writes cause wal checkpoint stalls.

### DIFF
--- a/storage/smartengine/core/db/db_impl_files.cc
+++ b/storage/smartengine/core/db/db_impl_files.cc
@@ -212,7 +212,8 @@ uint64_t DBImpl::MinLogNumberToKeep() {
 // force = false -- don't force the full scan, except every
 //  mutable_db_options_.delete_obsolete_files_period_micros
 // force = true -- force the full scan
-void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
+void DBImpl::FindObsoleteFiles(JobContext* job_context,
+                               bool force,
                                bool no_full_scan) {
   mutex_.AssertHeld();
 
@@ -273,6 +274,11 @@ void DBImpl::FindObsoleteFiles(JobContext* job_context, bool force,
   if (!alive_log_files_.empty() && IS_NOTNULL(curr_log_writer_)) {
     uint64_t min_log_number = job_context->log_number;
     size_t num_alive_log_files = alive_log_files_.size();
+
+    SE_LOG(INFO, "CK_INFO: find obsolete files",
+        K(min_log_number), K(num_alive_log_files),
+        "oldest_log_file_number", alive_log_files_.front().number,
+        "newest_log_file_number", alive_log_files_.back().number);
     // find newly obsoleted log files
     while (!alive_log_files_.empty() && alive_log_files_.begin()->number < min_log_number) {
       auto& earliest = *alive_log_files_.begin();

--- a/storage/smartengine/core/memtable/memtable.h
+++ b/storage/smartengine/core/memtable/memtable.h
@@ -295,7 +295,6 @@ class MemTable {
 
   uint64_t GetMinLogContainingPrepSection();
 
-  uint64_t get_temp_log_contain_prepsec();
   // Notify the underlying storage that no more items will be added.
   // REQUIRES: external synchronization to prevent simultaneous
   // operations on the same MemTable.
@@ -419,5 +418,6 @@ class MemTable {
 };
 
 extern const char* EncodeKey(std::string* scratch, const common::Slice& target);
-}
-}  // namespace smartengine
+
+} // namespace db
+} // namespace smartengine

--- a/storage/smartengine/core/memtable/memtable_list.cc
+++ b/storage/smartengine/core/memtable/memtable_list.cc
@@ -453,6 +453,7 @@ int MemTableList::purge_flushed_memtable(const util::autovector<MemTable *> &flu
     }
   }
   return ret;
-  }
-  }
-}  // namespace smartengine
+}
+
+} // namespace db
+} // namespace smartengine

--- a/storage/smartengine/handler/ha_smartengine.cc
+++ b/storage/smartengine/handler/ha_smartengine.cc
@@ -3690,6 +3690,9 @@ int ha_smartengine::build_table_schema(const TABLE *table,
       
     if (FAILED(build_column_schemas(table, field_decoders, table_schema.get_column_schemas()))) {
       SE_LOG(WARN, "fail to build column schemas", K(ret));
+    } else {
+      SE_LOG(INFO, "success to build table schema for table", "database_name", table_def->base_dbname(),
+          "table_name", table_def->base_tablename());
     }
   }
 


### PR DESCRIPTION
to #54 

PROBLEM
=======
Subtables with empty memtable do not advance their recovery points, causing the WAL checkpoint to stall while waiting for all subtables to align at a consistent WAL position.

CAUSE
=====
When the total wal size limit is reached, the system selects subtables occupying the oldest wal position for flushing. However, subtables with empty memtable are ignored during this process, as they have no data to flush. As a result, the recovery points of these subtables are not advanced, causing wal checkpoints to stall.

Previously, the advancement of recovery points for subtables with empty memtable was handled within the 'switch_memtable' process.However, this approach led to prolonged lock holding during the 'switch_memtable' operation, impacting system performance. To address this, the advancement of recovery points for empty memtable subtables was removed from the 'switch_memtable' process.

This change inadvertently introduced a scenario where recovery points for subtables with empty memtable might not be updated in certain cases. Consequently, these subtables remain stuck at older recovery points, blocking overall wal checkpoint progress.

SOLUTION
========
Reintroduce recovery point advancement for subtables with empty memtable during the wal checkpoint process, ensuring that all subtables, regardless of write activity, can contribute to checkpoint progress without holding locks excessively.
