### PR TITLE
fix: failed to purge the locally persisted binlog.

### DIFF
--- a/mysql-test/suite/smartengine_consistent_snapshot/r/binlog_archive_local_purge-wesql.result
+++ b/mysql-test/suite/smartengine_consistent_snapshot/r/binlog_archive_local_purge-wesql.result
@@ -1,0 +1,75 @@
+SET GLOBAL binlog_expire_logs_seconds=3;
+SET @@global.binlog_expire_logs_auto_purge = OFF;
+CREATE DATABASE db1;
+CREATE TABLE t1(c1 int, c2 char(200)) ENGINE=SMARTENGINE ;
+INSERT INTO t1 values(1,'abcd');
+FLUSH logs;
+INSERT INTO t1 values(6,'abcd');
+FLUSH logs;
+INSERT INTO t1 values(8,'abcd');
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1)
+binlog.000003
+SHOW CONSENSUS LOGS;
+Log_name	File_size	Start_log_index
+binlog.000001	#	#
+binlog.000002	#	#
+binlog.000003	#	#
+SET @@global.binlog_expire_logs_auto_purge = ON;
+FLUSH logs;
+INSERT INTO t1 values(8,'abcd');
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1)
+binlog.000004
+SHOW CONSENSUS LOGS;
+Log_name	File_size	Start_log_index
+binlog.000003	#	#
+binlog.000004	#	#
+SET @@global.binlog_expire_logs_auto_purge = OFF;
+FLUSH LOGS;
+INSERT INTO t1 values(16,'abcd');
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1)
+binlog.000005
+SHOW CONSENSUS LOGS;
+Log_name	File_size	Start_log_index
+binlog.000003	#	#
+binlog.000004	#	#
+binlog.000005	#	#
+CALL DBMS_CONSENSUS.PURGE_LOG(10000000);;
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1)
+binlog.000005
+SHOW CONSENSUS LOGS;
+Log_name	File_size	Start_log_index
+binlog.000005	#	#
+# Force suspend binlog persistent
+set global debug= '+d, force_suspend_binlog_persist_while_wait_for_mysql_binlog';
+SET @@global.binlog_expire_logs_auto_purge = ON;
+FLUSH LOGS;
+INSERT INTO t1 values(10,'abcd');
+FLUSH LOGS;
+INSERT INTO t1 values(11,'abcd');
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1)
+binlog.000005
+SHOW CONSENSUS LOGS;
+Log_name	File_size	Start_log_index
+binlog.000005	#	#
+binlog.000006	#	#
+binlog.000007	#	#
+# Signal binlog persistent
+set global debug= '-d, force_suspend_binlog_persist_while_wait_for_mysql_binlog';
+FLUSH LOGS;
+INSERT INTO t1 values(11,'abcd');
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1)
+binlog.000008
+SHOW CONSENSUS LOGS;
+Log_name	File_size	Start_log_index
+binlog.000007	#	#
+binlog.000008	#	#
+SET GLOBAL binlog_expire_logs_seconds=2592000;
+SET GLOBAL binlog_expire_logs_auto_purge=1;
+DROP TABLE t1;
+DROP DATABASE db1;

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_local_purge.cnf
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_local_purge.cnf
@@ -1,0 +1,7 @@
+!include suite/smartengine_consistent_snapshot/my.cnf
+
+[mysqld]
+binlog_archive_expire_auto_purge= false
+binlog_archive_slice_max_size= 4096
+binlog_archive_period=       1000
+snapshot_archive=           false

--- a/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_local_purge.test
+++ b/mysql-test/suite/smartengine_consistent_snapshot/t/binlog_archive_local_purge.test
@@ -1,0 +1,92 @@
+#
+# BUG#57
+# Test local binlog purge for binlog archive to object store.
+#
+--let $MYSQLD_DATADIR= `SELECT @@datadir`
+--let $saved_binlog_expire_logs_seconds= `SELECT @@GLOBAL.binlog_expire_logs_seconds`
+--let $saved_binlog_expire_logs_auto_purge= `SELECT @@GLOBAL.binlog_expire_logs_auto_purge`
+
+# set a low expiration window
+--let $retention_time_in_seconds = 3
+--let $sleep_time_in_seconds = `SELECT $retention_time_in_seconds * 2`
+--eval SET GLOBAL binlog_expire_logs_seconds=$retention_time_in_seconds
+
+# disable automatic purge
+SET @@global.binlog_expire_logs_auto_purge = OFF;
+
+CREATE DATABASE db1;
+CREATE TABLE t1(c1 int, c2 char(200)) ENGINE=SMARTENGINE ;
+INSERT INTO t1 values(1,'abcd');
+FLUSH logs;
+INSERT INTO t1 values(6,'abcd');
+FLUSH logs;
+INSERT INTO t1 values(8,'abcd');
+
+# sleep and last binlog should be persisted.
+--sleep $sleep_time_in_seconds
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+--replace_column 2 # 3 #
+SHOW CONSENSUS LOGS;
+
+SET @@global.binlog_expire_logs_auto_purge = ON;
+# Trigger consensus binlog auto purge.
+FLUSH logs;
+INSERT INTO t1 values(8,'abcd');
+
+--sleep $sleep_time_in_seconds
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+--replace_column 2 # 3 #
+SHOW CONSENSUS LOGS;
+
+#
+# ASSERT: If binlog_expire_logs_auto_purge is set to OFF, 
+# CALL DBMS_CONSENSUS.PURGE_LOG(1000) TO SHALL NOT be 
+# affected by the option.
+#
+SET @@global.binlog_expire_logs_auto_purge = OFF;
+FLUSH LOGS;
+INSERT INTO t1 values(16,'abcd');
+--sleep $sleep_time_in_seconds
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+--replace_column 2 # 3 #
+SHOW CONSENSUS LOGS;
+
+# Force purge binlog.
+--eval CALL DBMS_CONSENSUS.PURGE_LOG(10000000);
+--sleep $sleep_time_in_seconds
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+--replace_column 2 # 3 #
+SHOW CONSENSUS LOGS;
+
+--echo # Force suspend binlog persistent
+set global debug= '+d, force_suspend_binlog_persist_while_wait_for_mysql_binlog';
+
+# Enable auto purge
+SET @@global.binlog_expire_logs_auto_purge = ON;
+FLUSH LOGS;
+INSERT INTO t1 values(10,'abcd');
+FLUSH LOGS;
+INSERT INTO t1 values(11,'abcd');
+--sleep $sleep_time_in_seconds
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+--replace_column 2 # 3 #
+SHOW CONSENSUS LOGS;
+
+--echo  # Signal binlog persistent
+set global debug= '-d, force_suspend_binlog_persist_while_wait_for_mysql_binlog';
+--sleep $sleep_time_in_seconds
+
+# Trigger consensus binlog auto purge.
+FLUSH LOGS;
+INSERT INTO t1 values(11,'abcd');
+--sleep $sleep_time_in_seconds
+SELECT SUBSTRING_INDEX(LAST_PERSISTED_MYSQL_BINLOG, '/', -1) FROM INFORMATION_SCHEMA.BINLOG_PERSISTENT_TASK_INFO;
+--replace_column 2 # 3 #
+SHOW CONSENSUS LOGS;
+
+# clean up
+--eval SET GLOBAL binlog_expire_logs_seconds=$saved_binlog_expire_logs_seconds
+--eval SET GLOBAL binlog_expire_logs_auto_purge=$saved_binlog_expire_logs_auto_purge
+
+DROP TABLE t1;
+DROP DATABASE db1;

--- a/patches/mysql-server-8.0.35.patch
+++ b/patches/mysql-server-8.0.35.patch
@@ -3341,7 +3341,7 @@ index 5e20e06024e..5d5eebbcb4a 100644
    IO_CACHE m_io_cache;
  };
 diff --git a/sql/binlog.cc b/sql/binlog.cc
-index de76909ed3b..f9f14586ae3 100644
+index de76909ed3b..33b0c60b229 100644
 --- a/sql/binlog.cc
 +++ b/sql/binlog.cc
 @@ -40,6 +40,7 @@
@@ -3567,7 +3567,7 @@ index de76909ed3b..f9f14586ae3 100644
 +      // If binlog_archive is enabled, check if log file is persisted by
 +      // binlog_archive thread before purging it.
 +      if (compare_log_name(last_persisted_log_info.log_file_name,
-+                           log_info.log_file_name) > 0) {
++                           log_info.log_file_name) <= 0) {
 +        if (!auto_purge)
 +          push_warning_printf(
 +              thd, Sql_condition::SL_WARNING, ER_WARN_PURGE_LOG_NOT_PERSISTED,


### PR DESCRIPTION
fix #57 
When executing purge binlog(auto purge or manual purge), only the binlog that has been persisted can be purged. However, this bug will cause the binlog to be unable to be purged even if it has been persisted.