### PR TITLE
enhancement: make the failure message of creating directory clearer.

### DIFF
--- a/storage/smartengine/core/db/db_impl_open.cc
+++ b/storage/smartengine/core/db/db_impl_open.cc
@@ -218,7 +218,7 @@ int DBImpl::prepare_recovery(const ColumnFamilyOptions &cf_options)
                                          immutable_db_options_.wal_dir,
                                          immutable_db_options_.db_paths,
                                          immutable_db_options_.persistent_cache_dir).code())) {
-    SE_LOG(INFO, "fail to set directories", K(ret), K_(dbname),
+    SE_LOG(WARN, "fail to set directories", K(ret), K_(dbname),
         "wal_dir", immutable_db_options_.wal_dir, "persist_cache_dir", immutable_db_options_.persistent_cache_dir);
   } else if (FAILED(env_->LockFile(FileNameUtil::lock_file_path(dbname_), &db_lock_).code())) {
     SE_LOG(INFO, "fail to lock file", K(ret), K_(dbname));

--- a/storage/smartengine/core/env/env_posix.cc
+++ b/storage/smartengine/core/env/env_posix.cc
@@ -41,6 +41,7 @@
 #include <vector>
 
 #include "env/io_posix.h"
+#include "logger/log_module.h"
 #include "monitoring/iostats_context_imp.h"
 #include "monitoring/thread_status_updater.h"
 #include "objstore.h"
@@ -414,7 +415,7 @@ class PosixEnv : public Env
     while (SUCCED(ret) && (nullptr != (cursor_ptr = strchr(parent_ptr, '/')))) {
       if (parent_ptr != cursor_ptr) {
         *cursor_ptr = '\0';
-        do_mkdir(copy_path, mode);
+        ret = do_mkdir(copy_path, mode);
         *cursor_ptr = '/';
       }
       parent_ptr = cursor_ptr + 1;
@@ -762,9 +763,11 @@ private:
       //directory not exist, create it. EEXIST for race condition, more than one  thread create the same directory
       if (0 != mkdir(path, mode) && EEXIST != errno) {
         ret = Status::kIOError;
+        SE_LOG(WARN, "fail to create directory", K(ret), K(path), K(mode), K(errno), K(strerror(errno)));
       }
     } else if (!S_ISDIR(st.st_mode)) {
       ret = Status::kIOError;
+      SE_LOG(WARN, "the path is not a directory", K(ret), K(path));
     }
 
     return ret;

--- a/storage/smartengine/core/transactions/transaction_db_impl.cc
+++ b/storage/smartengine/core/transactions/transaction_db_impl.cc
@@ -150,14 +150,14 @@ Status TransactionDB::Open(const Options &options,
   TransactionDBImpl *trans_db_impl = nullptr;
 
   if (FAILED(DB::Open(options, db_name, handles, &db_ptr).code())) {
-    SE_LOG(WARN, "Fail to open db", K(ret));
+    SE_LOG(ERROR, "Fail to open db", K(ret));
   } else if (IS_NULL(trans_db_impl = new TransactionDBImpl(
           db_ptr,
           TransactionDBImpl::ValidateTxnDBOptions(trans_db_options)))) {
     ret = Status::kMemoryLimit;
-    SE_LOG(WARN, "Fail to allocate memory for TransactionDBImpl", K(ret));
+    SE_LOG(ERROR, "Fail to allocate memory for TransactionDBImpl", K(ret));
   } else if (FAILED(trans_db_impl->Initialize().code())) {
-    SE_LOG(WARN, "Fail to initialize TransactionDBImpl", K(ret));
+    SE_LOG(ERROR, "Fail to initialize TransactionDBImpl", K(ret));
   } else {
     *trans_db = trans_db_impl;
   }


### PR DESCRIPTION
It needs to create several directories during the startup process of SmartEngine, such as the data directory, the WAL directory, and the persistent cache directory, etc. The directory creating operation may fail for several reasons, like permission denied, space exhausted. We should print the detailed reason for the failure.
to #66 